### PR TITLE
Add missing settings.php

### DIFF
--- a/install/INSTALL.howto
+++ b/install/INSTALL.howto
@@ -38,15 +38,19 @@ BASIC INSTALLATION
    in this file to match your needs.
    % crontab crontab-for-orsee
 
-7. Browse to the 'config' dir. Edit the few settings in 'settings.php'.
+7. Copy settings-dist.php to 'config' directory and rename to 'settings.php'.
+   % cp settings-dist.php ../config/settings.php
+   % cd ../config/
 
-8. Make sure that the 'usage' directory is writable for the user under which the cronjob is running. The webalizer output will be saved there by the server.
+8. Edit the few settings in 'settings.php'.
 
-9. Browse to your ORSEE installation: 'http://yourorseewebpath/admin'.
+9. Make sure that the 'usage' directory is writable for the user under which the cronjob is running. The webalizer output will be saved there by the server.
 
-10. Login with username 'orsee_install' and password 'install'.
+10. Browse to your ORSEE installation: 'http://yourorseewebpath/admin'.
 
-11. Done.
+11. Login with username 'orsee_install' and password 'install'.
+
+12. Done.
 
 
 POST-INSTALLATION

--- a/install/settings-dist.php
+++ b/install/settings-dist.php
@@ -1,0 +1,69 @@
+<?php 
+// part of orsee. see orsee.org
+error_reporting(E_ALL & ~E_NOTICE);
+
+// SERVER SETTINGS
+// Web server document root, e.g. /srv/www/htdocs
+// no trailing slash!
+$settings__root_to_server="/srv/www/htdocs";
+
+// Experiment system root relative to server root, e.g. /orsee
+// begins always with "/" if in a subdirectory
+// no trailing slash!
+$settings__root_directory="/orsee";
+
+// url to web server document root (IP or domain name)
+// without trailing slash and the http://!
+//$settings__server_url="www.orsee.org";
+$settings__server_url="127.0.0.1";
+
+// servr protocol (either "http://" or "https://"
+$settings__server_protocol="http://";
+
+// Double-check your entries above! The URL to your ORSEE installation will be:
+// settings__server_protocol + settings__server_url + settings__root_directory
+
+
+// DATABASE CONFIGURATION
+// Don't forget to create the database
+$site__database_host="localhost";
+//$site__database_port="3306"; // set only if not default 3306
+$site__database_database="orsee_db";
+$site__database_admin_username="orsee_user";
+$site__database_admin_password="orsee_pw";
+$site__database_type="mysql";
+$site__database_table_prefix="or_";
+
+// TIMEZOME SETTING
+// PHP >= 5.1.0 requires the timezone to be explicitely set.
+// If you have not set it in php.ini, then set it here. (Otherwise, you can uncomment.)
+// List of timezones: http://php.net/manual/en/timezones.php
+date_default_timezone_set("Australia/Sydney");
+
+// EMAIL MODULE
+// These settings are only needed when you plan to enable the email module
+// to retrieve emails from an external email account and process them in ORSEE
+$settings__email_server_type="pop3"; // either pop3 or imap
+$settings__email_server_name="mail.foobar.edu";
+$settings__email_server_port=""; // if empty or not set, port is automatically determined by type
+$settings__email_username="orsee@foobar.edu";
+$settings__email_password="orseefoorbar_pw";
+
+
+// STOP SITE, TRACKING, DEBUGGING
+// If below is set to "y", the admin part of ORSEE won't be reachable for anybody
+// This is useful for example when running some procedures directly in the database
+$settings__stop_admin_site="n";
+
+// To stop tracking set to "y"
+$settings__disable_orsee_tracking="n";
+
+// Enable/disable debugging information output at the bottom fo each page. 
+// Do NOT ENABLE on a live ORSEE system - reveals a lot of information.
+$settings__time_debugging_enabled="n";
+$settings__query_debugging_enabled="n";
+
+// Include path for tagsets. Leave as is, only change when you know what you are doing.
+ini_set("include_path",ini_get("include_path").":./tagsets:./../tagsets:./../../tagsets");
+
+?>


### PR DESCRIPTION
The file was absent in the repo due to its presence in .gitignore file. While
we keep it "ignored" to make your repository clean and also for security
reasons, the fix adds the file to repo under different name and instruct user
to relocate and rename it upon installation.