### PR TITLE
Bug fix in redirect function

### DIFF
--- a/tagsets/site.php
+++ b/tagsets/site.php
@@ -41,7 +41,8 @@ function show_message() {
 function redirect($url) {
 	global $settings__root_url, $proceed;
 	$proceed=false;
-	if (preg_match("/^(http:\/\/|https:\/\/)/i",$url)) {
+       $url = urldecode($url);
+       if (preg_match("/^(http:\/\/|https:\/\/)/i",$url)) {
 		header("Location: ".trim($url));
 	} else {
 		$newurl=trim($settings__root_url."/".$url);


### PR DESCRIPTION
without the urldecode(); function, the initial redirect after admin login tries to go from

    /admin/admin_login.php?requested_url=admin/index.php%3f

to

    /admin%3findex.php%3f

which yeilds an error.