### PR TITLE
Feature: Allow SSL connections for retrieving emails

### DIFF
--- a/install/settings-dist.php
+++ b/install/settings-dist.php
@@ -48,6 +48,9 @@ $settings__email_server_name="mail.foobar.edu";
 $settings__email_server_port=""; // if empty or not set, port is automatically determined by type
 $settings__email_username="orsee@foobar.edu";
 $settings__email_password="orseefoorbar_pw";
+$settings__email_ssl=FALSE; // whether to use SSL to connect to IMAP/POP3 server (for gmail, use TRUE!)
+// E.g. for gmail, use TRUE for ssl setting. You may have to allow 
+// "Access for less secure apps" in your google account settings.
 
 
 // STOP SITE, TRACKING, DEBUGGING

--- a/tagsets/email.php
+++ b/tagsets/email.php
@@ -3,7 +3,7 @@
 
 function email__retrieve_incoming() {
     global $settings, $settings__email_server_type, $settings__email_server_name, $settings__email_server_port,
-            $settings__email_username, $settings__email_password;
+            $settings__email_username, $settings__email_password, $settings__email_ssl;
 
     $continue=true; $result=array(); $result['errors']=array();
     if (!isset($settings__email_server_type) || !in_array($settings__email_server_type,array('pop3','imap'))) {
@@ -22,12 +22,18 @@ function email__retrieve_incoming() {
         $result['errors'][]='No email username name given.';
         $continue=false;
     }
-    if (!isset($settings__email_server_port) || !$settings__email_server_port)
+    if (!isset($settings__email_server_port) || !$settings__email_server_port) {
         $settings__email_server_port=NULL;
+    }
+    if (!isset($settings__email_ssl) || !$settings__email_ssl) {
+        $settings__email_ssl=FALSE;
+    } else {
+        $settings__email_ssl=TRUE;
+    }
 
     if ($continue) {
         include_once('../tagsets/class.fmailbox.php');
-        $mailbox = new fMailbox($settings__email_server_type, $settings__email_server_name, $settings__email_username, $settings__email_password, $settings__email_server_port);
+        $mailbox = new fMailbox($settings__email_server_type, $settings__email_server_name, $settings__email_username, $settings__email_password, $settings__email_server_port,$settings__email_ssl);
         $messages = $mailbox->listMessages();
         $count=0;
         foreach ($messages as $message) {

--- a/tagsets/email.php
+++ b/tagsets/email.php
@@ -33,7 +33,7 @@ function email__retrieve_incoming() {
 
     if ($continue) {
         include_once('../tagsets/class.fmailbox.php');
-        $mailbox = new fMailbox($settings__email_server_type, $settings__email_server_name, $settings__email_username, $settings__email_password, $settings__email_server_port,$settings__email_ssl);
+        $mailbox = new fMailbox($settings__email_server_type, $settings__email_server_name, $settings__email_username, $settings__email_password, $settings__email_server_port, $settings__email_ssl);
         $messages = $mailbox->listMessages();
         $count=0;
         foreach ($messages as $message) {


### PR DESCRIPTION
Adds a new setting "settings__email_ssl" to config/settings.php, which will induce the email module to retrieve emails via IMAP using a SSL connection. This is required by gmail, for example.