### PR TITLE
Bugfix: Query errors caused by ONLY_FULL_GROUP_BY

### DIFF
--- a/admin/lang_edit.php
+++ b/admin/lang_edit.php
@@ -73,9 +73,8 @@ if ($proceed) {
         </FORM><BR>';
 
 
-    $query="select left(content_name,1) as letter,
-            count(lang_id) as number,
-            content_name
+    $query="select lower(left(content_name,1)) as letter,
+            count(lang_id) as number
             from ".table('lang')."
             where content_type='lang' GROUP BY letter";
     $result=or_query($query);

--- a/tagsets/cronjobs.php
+++ b/tagsets/cronjobs.php
@@ -332,12 +332,11 @@ function cron__check_for_session_reminders() {
     global $settings;
 
     $now=time();
-    $query="SELECT ".table('sessions').".*, ".table('experiments').".*, count(participate_id) as num_reg
-            FROM ".table('sessions').", ".table('participate_at').", ".table('experiments')."
-            WHERE ".table('sessions').".session_id=".table('participate_at').".session_id
-            AND ".table('sessions').".experiment_id = ".table('experiments').".experiment_id
-            AND session_status='live' AND reminder_sent = 'n' AND reminder_checked='n'
-            GROUP BY ".table('participate_at').".session_id";
+    $query="SELECT ".table('sessions').".*, ".table('experiments').".*,
+            (SELECT count(*) from ".table('participate_at')." as p1 WHERE p1.session_id=".table('sessions').".session_id) as num_reg 
+            FROM ".table('sessions').", ".table('experiments')."
+            WHERE ".table('sessions').".experiment_id = ".table('experiments').".experiment_id
+            AND session_status='live' AND reminder_sent = 'n' AND reminder_checked='n'";
     $result=or_query($query);
 
     $mess="";

--- a/tagsets/experiments.php
+++ b/tagsets/experiments.php
@@ -37,17 +37,14 @@ function experiment__current_experiment_summary($experimenter="",$finished="n",$
     $aquery=$finq.$expq.$classq;
 
         $query="SELECT ".table('experiments').".*,
-                count(*) as num_sessions,
-                if(session_start IS NULL, 1,0) as no_sessions,
-                min(if(session_start > date_format(now(),'%Y%m%d%H%i'),
-                session_start,NULL)) as time,
-                min(session_start) as first_session_date,
-                max(session_start) as last_session_date
+                (SELECT count(*) from ".table('sessions')." as s1 WHERE s1.experiment_id=".table('experiments').".experiment_id) as num_sessions,
+                if((SELECT count(*) from ".table('sessions')." as s2 WHERE s2.experiment_id=".table('experiments').".experiment_id)=0,1,0) as no_sessions,
+                (SELECT min(if(session_start > date_format(now(),'%Y%m%d%H%i'),session_start,NULL)) from ".table('sessions')." as s3 WHERE s3.experiment_id=".table('experiments').".experiment_id) as time,
+                (SELECT min(session_start) from ".table('sessions')." as s4 WHERE s4.experiment_id=".table('experiments').".experiment_id) as first_session_date,
+                (SELECT max(session_start) from ".table('sessions')." as s5 WHERE s5.experiment_id=".table('experiments').".experiment_id) as last_session_date 
                 FROM ".table('experiments')."
-                LEFT JOIN ".table('sessions')." ON ".table('experiments').".experiment_id=".table('sessions').".experiment_id
                 WHERE ".table('experiments').".experiment_id IS NOT NULL
                 AND ".$aquery."
-                GROUP BY experiment_id
                 ORDER BY no_sessions, time, last_session_date DESC, experiment_id";
         $result=or_query($query,$pars);
         $experiments=array(); $eids=array();


### PR DESCRIPTION
Actually, I think this bugfix would need some thorough longer-term testing in some busy ORSEE production installation before being released to the wild ...

More details: https://dev.mysql.com/doc/refman/5.7/en/group-by-handling.html
As of  version 5.7.5, the default SQL mode in MySQL includes ONLY_FULL_GROUP_BY as a default. In earlier MySQL versions, ONLY_FULL_GROUP_BY was not enabled. The ONLY_FULL_GROUP_BY SQL mode requires that a SELECT statement with a GROUP BY clause only refers to aggregated columns or to columns named in the GROUP BY clause. As a result, some ORSEE queries (most prominently the query which delivers the list of currrent (past, own) experiments thorws an error. This could be switched off by disabling ONLY_FULL_GROUP_BY as an SQL mode.
This bugfix fixes some queries (partly replacing group-by clauses with subqueries) such that this error does not appear anymore and ORSEE works fine with SQL mode ONLY_FULL_GROUP_BY enabled.