### PR TITLE
Feature: "Edit" links in session& assign lists (hat-tip S. Billeter)

### DIFF
--- a/admin/experiment_add_participants.php
+++ b/admin/experiment_add_participants.php
@@ -4,7 +4,7 @@ ob_start();
 
 $menu__area="experiments";
 $title="assign_subjects";
-$jquery=array('arraypicker','textext','dropit','queryform','datepicker');
+$jquery=array('arraypicker','textext','dropit','queryform','datepicker','popup');
 include ("header.php");
 if ($proceed) {
     if ($_REQUEST['experiment_id']) $experiment_id=$_REQUEST['experiment_id'];
@@ -85,6 +85,10 @@ if ($proceed) {
             $_SESSION['lastquery_assign_'.$experiment_id] =  $posted_query_json;
             $_SESSION['lastqueryid_assign_'.$experiment_id] =  $query_id;
             $sort=query__load_default_sort('assign',$experiment_id);
+        }
+
+        if (check_allow('participants_edit')) {
+            echo javascript__edit_popup();
         }
 
         // show query in human-readable form

--- a/admin/experiment_drop_participants.php
+++ b/admin/experiment_drop_participants.php
@@ -4,7 +4,7 @@ ob_start();
 
 $menu__area="experiments";
 $title="remove_participants_from_exp";
-$jquery=array('arraypicker','textext','dropit','queryform','datepicker');
+$jquery=array('arraypicker','textext','dropit','queryform','datepicker','popup');
 include ("header.php");
 if ($proceed) {
     if ($_REQUEST['experiment_id']) $experiment_id=$_REQUEST['experiment_id'];
@@ -81,6 +81,10 @@ if ($proceed) {
             $_SESSION['lastquery_deassign_'.$experiment_id] =  $posted_query_json;
             $_SESSION['lastqueryid_deassign_'.$experiment_id] =  $query_id;
             $sort=query__load_default_sort('assign',$experiment_id);
+        }
+
+        if (check_allow('participants_edit')) {
+            echo javascript__edit_popup();
         }
 
         // show query in human-readable form

--- a/admin/experiment_participants_show.php
+++ b/admin/experiment_participants_show.php
@@ -328,6 +328,10 @@ if ($proceed) {
     }
     unset($temp_participants);
 
+    if (check_allow('participants_edit')) {
+        echo javascript__edit_popup();
+    }
+
     echo '<center>';
 
     echo '<TABLE class="or_page_subtitle" style="background: '.$color['page_subtitle_background'].'; color: '.$color['page_subtitle_textcolor'].'; width: 95%">

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -1300,7 +1300,7 @@ function participant__get_possible_participant_columns($listtype) {
         $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
-        //$cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='result_table_search_duplicates') {
         $cols['pform_fields']='';
         $cols['other_pfields']='';
@@ -1316,6 +1316,7 @@ function participant__get_possible_participant_columns($listtype) {
         $cols['pform_fields']='';
         $cols['other_pfields']='';
         $cols['invited']=array('display_text'=>lang('invited'),'on_list'=>true,'allow_remove'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='session_participants_list') {
         $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
         $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false);
@@ -1326,6 +1327,7 @@ function participant__get_possible_participant_columns($listtype) {
         $cols['payment_type']=array('display_text'=>lang('payment_type'),'display_table_head'=>lang('payment_type_abbr'),'on_list'=>true,'allow_remove'=>false);
         $cols['payment_amount']=array('display_text'=>lang('payment_amount'),'display_table_head'=>lang('payment_amount_abbr'),'on_list'=>true,'allow_remove'=>false,'sort_order'=>'payment_amt');
         $cols['pstatus_id']=array('display_text'=>lang('participation_status'),'on_list'=>true,'allow_remove'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='session_participants_list_pdf') {
         $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false);
         $cols['pform_fields']='';


### PR DESCRIPTION
This small change allows the ORSEE user to add an "Edit" profile link column to the participant results lists when assigning/de-assigning participants to an experiment, or when showing assigned or enroled participants of an experiment/session. This way, participant profiles can be directly edited from there.

The default is that these "Edit" links are not included in these lists, they can be added as a column from Options/Configure query result lists.

There was a risk that javascript used on these results lists might interfere with the javascript used for displaying the participant profile form, but no such problems have been detected in testing. 