### PR TITLE
Bugfix: SQL error when ordering by participant ID

### DIFF
--- a/admin/experiment_participants_show.php
+++ b/admin/experiment_participants_show.php
@@ -294,7 +294,9 @@ if ($proceed) {
     foreach ($clause_pars as $p=>$v) $pars[$p]=$v;
 
     $order=query__get_sort('session_participants_list',$sort);  // sanitize sort or load default if empty
-    if(!$order) $order=table('participants').".participant_id"; //??
+    if((!$order) || $order=='participant_id') {
+        $order=table('participants').".participant_id";
+    }
     $query.=" ORDER BY ".$order;
 
     // get result


### PR DESCRIPTION
In the list of participants for a session, when the column "Participant ID" is displayed, and then the user clicks on the "Participant ID" column head to order the list by participant id, it returnes an SQL error, complaining that participant_id used in the ORDER BY statement is ambiguous. This is because the query combines two tables or_participants and or_participate_at, both of which use particpant.

The bugfix makes sure that when the list is ordered by participant_id, then the query uses "or_participants.participant_id".