### PR TITLE
Bugfix: Ordering of select_lang items

### DIFF
--- a/admin/options_participant_profile_edit.php
+++ b/admin/options_participant_profile_edit.php
@@ -179,7 +179,7 @@ if ($proceed) {
 
     echo '<TR class="condfield radioline_lang tooltip" title="Whether to sort values of this field by the order predetermined in &quot;Options/Items for profile fields of type select_lang/radioline_lang&quot; or alphabetically in the respective language.">
             <TD>Order values</TD>
-            <TD>'.pform_options_selectfield('order_select_lang_values',array('alphabetically','fixed_order'),$field).'</TD></TR>';
+            <TD>'.pform_options_selectfield('order_radio_lang_values',array('alphabetically','fixed_order'),$field).'</TD></TR>';
 
 
     echo '<TR class="condfield select_numbers tooltip" title="First number in list. Must be integer."><TD>Start number

--- a/tagsets/language.php
+++ b/tagsets/language.php
@@ -85,7 +85,7 @@ function language__selectfield_item($content_type,$ptablevarname,$formfieldvarna
     $query="SELECT *, ".$language." AS item
             FROM ".table('lang')."
             WHERE content_type= :content_type
-            ORDER BY ".pdo_escape_string($order_by);
+            ORDER BY ".$order_by;
     $result=or_query($query,$pars);
     while ($line = pdo_fetch_assoc($result)) {
         $items[$line['content_name']]=$line['item'];

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -329,6 +329,7 @@ $array=array(
 'include_in_statistics'=>'n',
 'include_none_option'=>'n',
 'order_select_lang_values'=>'alphabetically',
+'order_radio_lang_values'=>'alphabetically',
 'link_as_email_in_lists'=>'n',
 'list_in_session_participants_list'=>'n',
 'list_in_session_pdf_list'=>'n',
@@ -514,7 +515,7 @@ function form__render_select_lang($f) {
 
 function form__render_radioline_lang($f) {
     if ($f['include_none_option']=='y') $incnone=true; else $incnone=false;
-    $out=language__radioline_item($f['mysql_column_name'],$f['mysql_column_name'],$f['mysql_column_name'],$f['value'],$incnone,$f['order_select_lang_values']);
+    $out=language__radioline_item($f['mysql_column_name'],$f['mysql_column_name'],$f['mysql_column_name'],$f['value'],$incnone,$f['order_radio_lang_values']);
     return $out;
 }
 


### PR DESCRIPTION
The order of select_lang items (e.g. profession, field of studies in the default database) could not be changed. 1) There was a problem with equally named option fields on the profile form field definition page, 2) the order by "order_number" waor language was escaped in the SQL query and taken as a string, leading to a random order. Both issues were fixed in this commit.