### PR TITLE
Feature: Automatically upgrade database after software update

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -61,6 +61,8 @@ if ($proceed) {
 
     $lang=load_language($expadmindata['language']);
 
+    $done=check_database_upgrade();
+
     if (!isset($title)) $title="";
     if ($title) $title=lang($title);
     $pagetitle=$settings['default_area'].': '.$title;

--- a/tagsets/orsee_mysql.php
+++ b/tagsets/orsee_mysql.php
@@ -247,5 +247,39 @@ function dump_array($array,$title="",$dolang=true) {
     echo '</TABLE>';
 }
 
+function version_to_integer($version) {
+    $varray=explode(".",$version);
+    $version_int=$varray[0]*10000+$varray[1]*100+$varray[2]*1;
+    return $version_int;
+}
+
+function check_database_upgrade() {
+    global $settings, $system__version;
+
+    if (!isset($settings['database_version'])) {
+        $settings['database_version']='3.0.2';
+    }
+    $current_system_version_int=version_to_integer($system__version);
+    $db_version_int=version_to_integer($settings['database_version']);
+    if ($db_version_int<$current_system_version_int) {
+        $done=or_upgrade_database($old_db_version_int);
+        $done=orsee_db_save_array(array('option_value'=>$system__version),'options',1,'option_id');
+        return $done;
+    } else {
+        return false;
+    }
+}
+
+function or_upgrade_database($old_version_int) {
+    global $settings;
+    if ($old_version<30003) {
+        if (!isset($settings['database_version'])) {
+            $done=or_query("INSERT INTO ".table('or_options')." VALUES (1,'general',NULL,'database_version','3.0.3')");
+        }
+    }
+    
+    // further database upgrade, to be added with each new ORSEE version if necessary
+
+}
 
 ?>


### PR DESCRIPTION
These new functions automatically upgrade the database content and structure to the repective new software version.
- The new function check_database_upgrade() in tagsets/orsee_mysql.php checks whether the current database version (stored in the or_options table) is older than the current software version. In doing so in makes use of a new helper function version_to_integer(). If the databse version is older than the system version, then it runs the function or_upgrade_database() and after that updates the database version.
- This commit also adds new helper functions in tagsets/language.php named lang__check_symbol_exists(), lang__add_new_symbol(), and lang__upgrade_symbol_if_not_exists(). These functions (in particular the last one) can be used in in or_upgrade_database() to execute the most common task when upgrading the database: adding new language symbols to the language table. New symbols will be added in the respective langauges if given, other languages will be filled with the English term and can then be translated by the user.