### PR TITLE
Feature: Disable js auto-submit on admin login form

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -664,6 +664,13 @@ $system__options_general[]=array(
 'maxlength'=>'5',
 );
 
+$system__options_general[]=array(
+'option_name'=>'disable_admin_login_js',
+'option_text'=>'Disable auto-submit on admin login form? (May interfere with some browser autofill functions.)',
+'type'=>'select_yesno_switchy',
+'default_value'=>'n'
+);
+
 $system__options_general[]=array('type'=>'line');
 
 $system__options_general[]=array('type'=>'comment',

--- a/tagsets/expadmin.php
+++ b/tagsets/expadmin.php
@@ -3,12 +3,20 @@
 
 // login form
 function admin__login_form() {
-    global $lang;
+    global $lang, $settings;
     echo '<form name="login" action="admin_login.php" method=post>
         '.lang('username').':
-        <input type=text size=20 maxlength=20 name=adminname onChange="gotoPassword()"><BR>
+        <input type=text size=20 maxlength=20 name=adminname';
+    if (!(isset($settings['disable_admin_login_js']) && $settings['disable_admin_login_js']=='y')) {
+        echo ' onChange="gotoPassword()"';
+    }
+    echo '><BR>
         '.lang('password').':
-        <input type=password size=20 maxlength=20 name=password onChange="sendForm()"><BR>';
+        <input type=password size=20 maxlength=20 name=password';
+    if (!(isset($settings['disable_admin_login_js']) && $settings['disable_admin_login_js']=='y')) {
+        echo ' onChange="sendForm()"';
+    }
+    echo '><BR>';
     if (isset($_REQUEST['requested_url']) && $_REQUEST['requested_url'])
         echo '<input type=hidden name="requested_url" value="'.$_REQUEST['requested_url'].'">';
     echo '<input class="button" type=submit name=login value="'.lang('login').'">

--- a/tagsets/html_stuff.php
+++ b/tagsets/html_stuff.php
@@ -85,7 +85,9 @@ echo '<HTML>
 ';
 
 
-if (thisdoc()=="admin_login.php") script__login_page();
+if (thisdoc()=="admin_login.php" && (!(isset($settings['disable_admin_login_js']) && $settings['disable_admin_login_js']=='y'))) {
+    script__login_page();
+}
 
 if (isset($jquery) && is_array($jquery)) {
     include_jquery('',false);
@@ -137,7 +139,9 @@ if (isset($color['body_vlink'])) echo ' vlink="'.$color['body_vlink'].'"';
 if (isset($color['body_alink'])) echo ' alink="'.$color['body_alink'].'"';
 if (isset($color['shade_around_content'])) echo ' bgcolor="'.$color['shade_around_content'].'"';
 echo ' TOPMARGIN=0 LEFTMARGIN=0 MARGINWIDTH=0 MARGINHEIGHT=0';
-if (thisdoc()=="admin_login.php") echo ' onload="gotoUsername();"';
+if (thisdoc()=="admin_login.php" && (!(isset($settings['disable_admin_login_js']) && $settings['disable_admin_login_js']=='y'))) {
+    echo ' onload="gotoUsername();"';
+}
 echo '>
 ';
 


### PR DESCRIPTION
Adds a switch to the Options/General settings page that allows to disable the javascript autosubmit functionality on the admin login form. This functionality aims to make the login process more convenient, by 1) automatically activating the username field when accessing the page, 2) switching to the password field once the username is entered, and 3) auto-submitting the login form (withou a need to click the login button) once the password is entered. However, this functionality interferes with the username/password autofill functionality in some browsers, since that autofill functionality may include an autosubmit. As a result, when the stored password elapses, the browser may automatically prodcue hundreds of failed login attempts by repeatedly auo-filling the login form and auto-submitting it.
In config/system.php we added the switch. In tagsets/expadmin.php now the javascript function calls are not included in the login form when the switch is enabled. In tagsets/html_stuff.php the resepctive javascript function definitions are not included when the switch is enabled.