### PR TITLE
Bugfix: Query error on select_numbers

### DIFF
--- a/tagsets/query.php
+++ b/tagsets/query.php
@@ -213,7 +213,7 @@ function query__get_query($query_array,$query_id,$additional_clauses,$sort,$reso
         $add_queries=array();
         foreach ($additional_clauses as $add_clause) {
             foreach ($add_clause['pars'] as $p=>$v) {
-                $add_clause['query']=preg_replace('/'.$p.'([^0-9])/',$p.'_'.$i.'\\1',$add_clause['query']);
+                $add_clause['query']=preg_replace('/'.$p.'([^0-9])/',$p.'_'.$i.'\\1',$add_clause['query'].' ');
                 $pars[$p.'_'.$i]=$v;
             }
             $i++;
@@ -232,7 +232,7 @@ function query__get_query($query_array,$query_id,$additional_clauses,$sort,$reso
         } else {
             if (isset($q['subqueries'])) $q['clause']=query__get_subqueries($q['clause'],$q['subqueries'],$resolve_subqueries);
             foreach ($q['clause']['pars'] as $p=>$v) {
-                $q['clause']['query']=preg_replace('/'.$p.'([^0-9])/',$p.'_'.$i.'\\1',$q['clause']['query']);
+                $q['clause']['query']=preg_replace('/'.$p.'([^0-9])/',$p.'_'.$i.'\\1',$q['clause']['query'].' ');
                 $pars[$p.'_'.$i]=$v;
             }
             $i++;


### PR DESCRIPTION
The bugfix 'Query error with 10+ items in "prior participation"' included in version 3.0.5 used a preg_replace pattern replacement function, which makes sure that in the resulting query all parameters have unqiue names (even if a query module is used repeatedly within the same query). However, part of the pattern does not match the number query. An easy fix is just to add a space to the end of the respective query part (which does do no harm anywere), such that the pattern matches and the parameter name is properly replaced in the query.