### PR TITLE
Feature: Allow to set default for restricting access to experiments

### DIFF
--- a/admin/experiment_edit.php
+++ b/admin/experiment_edit.php
@@ -76,7 +76,7 @@ if ($proceed) {
 
             if (!isset($_REQUEST['hide_in_cal']) ||!$_REQUEST['hide_in_cal']) $_REQUEST['hide_in_cal']="n";
 
-            if (!isset($_REQUEST['access_restricted']) ||!$_REQUEST['access_restricted']) $_REQUEST['access_restricted']="n";
+            if (!isset($_REQUEST['access_restricted']) ||!$_REQUEST['access_restricted']) $_REQUEST['access_restricted']='n';
 
 
 
@@ -120,6 +120,7 @@ if ($proceed) {
         foreach ($formvarnames as $fvn) {
             if (!isset($edit[$fvn])) $edit[$fvn]="";
         }
+	$edit['access_restricted']=$settings['default_experiment_restriction'];
     }
     if (!$edit['ethics_expire_date']) $edit['ethics_expire_date']=ortime__unixtime_to_sesstime()+100000000;
 

--- a/config/system.php
+++ b/config/system.php
@@ -640,6 +640,13 @@ $system__options_general[]=array(
 );
 
 $system__options_general[]=array(
+'option_name'=>'default_experiment_restriction',
+'option_text'=>'If restriction enabled: Should a new experiment be restricted by default?',
+'type'=>'select_yesno_switchy',
+'default_value'=>'n'
+);
+
+$system__options_general[]=array(
 'option_name'=>'admin_password_regexp',
 'option_text'=>'Regular expression for admin passwords (default: PW between 8 and 20 characters long,
                  at least one lower-case letter (a-z), one upper-case (A-Z), one digit (0-9)).


### PR DESCRIPTION
This adds an option to Options/General Settings that allows to set a default for the "experiment restricted" setting on the experiment creation/edit page.