### PR TITLE
Bugfix: SQL error multiple participation statuses

### DIFF
--- a/tagsets/expregister.php
+++ b/tagsets/expregister.php
@@ -389,7 +389,7 @@ function expregister__get_pstatus_query_snippet($what="participated",$reverse=fa
     $psarr=expregister__get_specific_pstatuses($what,$reverse);
     if (count($psarr)==1) return " pstatus_id='".$psarr[0]."' ";
     else {
-        return " pstatus_id= ANY (".implode(", ",$psarr).") ";
+        return " pstatus_id IN (".implode(", ",$psarr).") ";
         //$check_statuses_query=array();
         //foreach ($psarr as $cs) $check_statuses_query[]=" pstatus_id='".$cs."' ";
         //$snippet=" (".implode(" OR ",$check_statuses_query).") ";


### PR DESCRIPTION
In function expregister__get_pstatus_query_snippet() in tagsets/expregister.php, the query snippet used the SQL operator ANY() to match against a list. The ANY() operator can only be used with subqueries, not with lists of values. So it was now replaced by the IN() operator.