### PR TITLE
Feature: Participant form link in mail queue

### DIFF
--- a/admin/experiment_mailqueue_show.php
+++ b/admin/experiment_mailqueue_show.php
@@ -2,7 +2,7 @@
 // part of orsee. see orsee.org
 ob_start();
 
-$jquery=array();
+$jquery=array('popup');
 $title="mailqueue";
 $menu__area="statistics";
 include ("header.php");

--- a/admin/mailqueue_show.php
+++ b/admin/mailqueue_show.php
@@ -2,7 +2,7 @@
 // part of orsee. see orsee.org
 ob_start();
 
-$jquery=array();
+$jquery=array('popup');
 $title="mailqueue";
 $menu__area="statistics";
 include ("header.php");

--- a/tagsets/mailqueue.php
+++ b/tagsets/mailqueue.php
@@ -154,6 +154,11 @@ if ($proceed) {
     if ($num_rows >= $limit) echo '['.log__link('os='.($offset+$limit)).lang('next').'</A>]';
     else echo '['.lang('next').']';
 
+
+    if (check_allow('participants_edit')) {
+        echo javascript__edit_popup();
+    }
+
     echo '<TABLE class="or_listtable" style="width: 90%;"><thead>';
     // header
     echo '
@@ -207,7 +212,9 @@ if ($proceed) {
             <TD>'.$line['mail_id'].'</TD>
             <TD>'.ortime__format($line['timestamp'],'hide_second:false',lang('lang')).'</TD>
             <TD>'.$line['mail_type'].'</TD>
-            <TD>'.$line['mail_recipient'].'</TD>
+            <TD>'.$line['mail_recipient'];
+        if (check_allow('participants_edit')) echo ' <FONT class="small">'.javascript__edit_popup_link($line['mail_recipient']).'</FONT>';
+        echo '</TD>
             <TD>';
         $reference=array();
         if ($line['experiment_id']) $reference[]='Experiment: <A HREF="experiment_show.php?experiment_id='.$line['experiment_id'].'">'.$experiments[$line['experiment_id']]['experiment_name'].'</A>';


### PR DESCRIPTION
This code adds a link to a participant form popup to the "recipient" column in the mailqueue. It will only be displayed if the respective administrator has the access right to edit participant forms. This feature will allow to more conveniently edit participant details for those participants where email sending returns an error.