### PR TITLE
Bugfix: create_function() deprecated in PHP 7.2

### DIFF
--- a/tagsets/helpers.php
+++ b/tagsets/helpers.php
@@ -15,18 +15,15 @@ function support_mail_link() {
 }
 
 function multi_array_sort(&$data, $sortby) {
-    $sortby1=""; $sortby2=""; $sortby3="";
+    $sorting_var1=""; $sorting_var2=""; $sorting_var3="";
     if (is_array($sortby)) {
-        $sortby1 = $sortby[0];
-        if (isset($sortby[1])) $sortby2 = $sortby[1];
-        if (isset($sortby[2])) $sortby3 = $sortby[2];
+        $sorting_var1 = $sortby[0];
+        if (isset($sortby[1])) $sorting_var2 = $sortby[1];
+        if (isset($sortby[2])) $sorting_var3 = $sortby[2];
     } else {
-        $sortby1 = $sortby;
+        $sorting_var1 = $sortby;
     } 
-    global $sorting_var1, $sorting_var2, $sorting_var3;
-    $sorting_var1=$sortby1; $sorting_var2=$sortby2; $sorting_var3=$sortby3;
-    uasort($data,function ($a,$b) {
-        global $sorting_var1, $sorting_var2, $sorting_var3;
+    uasort($data,function ($a,$b) use ($sorting_var1, $sorting_var2, $sorting_var3) {
         if ($a[$sorting_var1]!=$b[$sorting_var1] || (!$sorting_var2)) {
             return $a[$sorting_var1]>$b[$sorting_var1];
         } elseif ($a[$sorting_var2]!=$b[$sorting_var2] || (!$sorting_var3)) {

--- a/tagsets/helpers.php
+++ b/tagsets/helpers.php
@@ -15,25 +15,26 @@ function support_mail_link() {
 }
 
 function multi_array_sort(&$data, $sortby) {
-    static $sort_funcs = array();
-
+    $sortby1=""; $sortby2=""; $sortby3="";
     if (is_array($sortby)) {
-            $sortby = join(',',$sortby);
+        $sortby1 = $sortby[0];
+        if (isset($sortby[1])) $sortby2 = $sortby[1];
+        if (isset($sortby[2])) $sortby3 = $sortby[2];
+    } else {
+        $sortby1 = $sortby;
+    } 
+    global $sorting_var1, $sorting_var2, $sorting_var3;
+    $sorting_var1=$sortby1; $sorting_var2=$sortby2; $sorting_var3=$sortby3;
+    uasort($data,function ($a,$b) {
+        global $sorting_var1, $sorting_var2, $sorting_var3;
+        if ($a[$sorting_var1]!=$b[$sorting_var1] || (!$sorting_var2)) {
+            return $a[$sorting_var1]>$b[$sorting_var1];
+        } elseif ($a[$sorting_var2]!=$b[$sorting_var2] || (!$sorting_var3)) {
+            return $a[$sorting_var2]>$b[$sorting_var2];
+        } else {
+            return $a[$sorting_var3]>$b[$sorting_var3];
         }
-
-    if (empty($sort_funcs[$sortby])) {
-            $code = "\$c=0;";
-            $sortby_arr=explode(',', $sortby);
-            foreach ($sortby_arr as $key) {
-                $code .= "if ( (\$c = strcasecmp(\$a['$key'],\$b['$key'])) != 0 ) return \$c;\n";
-                }
-            $code .= 'return $c;';
-            $sort_func = $sort_funcs[$sortby] = create_function('$a, $b', $code);
-     } else {
-            $sort_func = $sort_funcs[$sortby];
-        }
-    $sort_func = $sort_funcs[$sortby];
-    uasort($data, $sort_func);
+    });
 }
 
 // debug output


### PR DESCRIPTION
The anonymous function builder create_function() was deprecated in PHP 7.2. This function was only used in function multi_array_sort() in file tagsets/helpers.php. This fix replaces that function by a new function that allows to sort multi-dimensional arrays (on up to 3 columns).