### PR TITLE
Feature: More experiment details in invitiation email (public experim…

### DIFF
--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -663,9 +663,11 @@ function experimentmail__get_invitation_mail_details($part,$exp,$slist) {
     $part['experiment_name']=$exp['experiment_public_name'];
     $part['sessionlist']=$slist;
     $part['link']=experimentmail__build_lab_registration_link($part);
+    $part['public_experiment_note']=$exp['public_experiment_note'];
+    $part['ethics_by']=$exp['ethics_by'];
+    $part['ethics_number']=$exp['ethics_number'];
     return $part;
 }
-
 
 function experimentmail__send_invitation_mail($mail,$part,$exp,$inv_text,$slist,$footer) {
     global $settings;


### PR DESCRIPTION
…ent note, ethics details)

This change makes a few more variables from the or_experiments table available for use in the invitation email template. In addition to all details from the participant table, these variables now include:  #edit_link# #enrolment_link# #experiment_name# #sessionlist# #link# #public_experiment_note# #ethics_by# #ethics_number#