### PR TITLE
Bugfix: Definition of pool id array in pform

### DIFF
--- a/public/participant_create.php
+++ b/public/participant_create.php
@@ -10,7 +10,7 @@ if ($proceed) {
     if (!(isset($_SESSION['subpool_id']))) {
         // get available subpools
         $subpools=subpools__get_subpools();
-        $all_avail_pool_ids=array();
+        $all_pool_ids=array();
         foreach ($subpools as $pool) {
             if ($pool['subpool_id']>1 && $pool['show_at_registration_page']=='y') {
                 $all_pool_ids[]=$pool['subpool_id'];


### PR DESCRIPTION
This but fixes a small typo that may lead to a PHP error about the array $all_pool_ids not being defined.