### PR TITLE
Feature: Automatic database upgrade

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -61,6 +61,8 @@ if ($proceed) {
 
     $lang=load_language($expadmindata['language']);
 
+    $done=check_database_upgrade();
+
     if (!isset($title)) $title="";
     if ($title) $title=lang($title);
     $pagetitle=$settings['default_area'].': '.$title;

--- a/config/dbupdates.php
+++ b/config/dbupdates.php
@@ -1,0 +1,43 @@
+<?php
+// part of orsee. see orsee.org
+// THIS FILE WILL CHANGE FROM VERSION TO VERSION. BETTER NOT EDIT.
+
+
+// DATABASE UPGRADE DEFINITIONS //
+// add entries to array $system__database_upgrades
+
+
+/* SAMPLE CODE FOR UPGRADES
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'new_lang_item', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'content_name'=>'', // *for new_lang_item: shortcut for item
+    'content_type'=>'', // for new_lang_item: type for item, default: lang
+    'content'=>array('en'=>'','de'=>''),    // *for new_lang_item: one expression for each language, first one is taked as default and filled in for non-existing languages
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'new_admin_right', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'right_name'=>'', // *for new_admin_right: shortcut for admin right
+    'admin_types'=>array('admin','experimenter'),    // *for new_admin_right: list of admin types for which this right should be set (if not exists yet)
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'query', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'query_code'=>'' // *for query: SQL statement to be executed. You can use "TABLE(tablename)" to have "or_" or the respective ORSEE table rpefix automatically prepended
+    )
+);
+
+END SAMPLE CODE
+*/
+
+
+?>

--- a/config/system.php
+++ b/config/system.php
@@ -2,6 +2,7 @@
 // part of orsee. see orsee.org
 // THIS FILE WILL CHANGE FROM VERSION TO VERSION. BETTER NOT EDIT.
 $system__version="3.0.5";
+$system__database_version="2020021000";
 
 // implemented experiment types
 $system__experiment_types=array('laboratory','online-survey','internet');
@@ -1676,6 +1677,42 @@ $system__colors[]=array(
 'default_value'=>''
 );
 
+*/
+
+
+// DATABASE UPGRADE DEFINITIONS //
+$system__database_upgrades=array();
+
+/* SAMPLE CODE FOR UPGRADES
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'new_lang_item', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'content_name'=>'', // *for new_lang_item: shortcut for item
+    'content_type'=>'', // for new_lang_item: type for item, default: lang
+    'content'=array('en'=>'','de'=>''),    // *for new_lang_item: one expression for each language, first one is taked as default and filled in for non-existing languages
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'new_admin_right', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'right_name'=>'', // *for new_admin_right: shortcut for admin right
+    'admin_types'=array('admin','experimenter'),    // *for new_admin_right: list of admin types for which this right should be set (if not exists yet)
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2020021000', // *database version from which on this is expected
+'type'=>'query', // *can be: new_lang_item, new_admin_right, query
+'specs'=> array(
+    'query_code'=>'' // *for query: SQL statement to be executed. You can use "TABLE(tablename)" to have "or_" or the respective ORSEE table rpefix automatically prepended
+    )
+);
+
+END SAMPLE CODE
 */
 
 

--- a/config/system.php
+++ b/config/system.php
@@ -2,7 +2,7 @@
 // part of orsee. see orsee.org
 // THIS FILE WILL CHANGE FROM VERSION TO VERSION. BETTER NOT EDIT.
 $system__version="3.0.5";
-$system__database_version="2020021000";
+$system__database_version=2020021000;
 
 // implemented experiment types
 $system__experiment_types=array('laboratory','online-survey','internet');
@@ -1682,38 +1682,6 @@ $system__colors[]=array(
 
 // DATABASE UPGRADE DEFINITIONS //
 $system__database_upgrades=array();
-
-/* SAMPLE CODE FOR UPGRADES
-
-$system__database_upgrades[]=array(
-'version'=>'2020021000', // *database version from which on this is expected
-'type'=>'new_lang_item', // *can be: new_lang_item, new_admin_right, query
-'specs'=> array(
-    'content_name'=>'', // *for new_lang_item: shortcut for item
-    'content_type'=>'', // for new_lang_item: type for item, default: lang
-    'content'=array('en'=>'','de'=>''),    // *for new_lang_item: one expression for each language, first one is taked as default and filled in for non-existing languages
-    )
-);
-
-$system__database_upgrades[]=array(
-'version'=>'2020021000', // *database version from which on this is expected
-'type'=>'new_admin_right', // *can be: new_lang_item, new_admin_right, query
-'specs'=> array(
-    'right_name'=>'', // *for new_admin_right: shortcut for admin right
-    'admin_types'=array('admin','experimenter'),    // *for new_admin_right: list of admin types for which this right should be set (if not exists yet)
-    )
-);
-
-$system__database_upgrades[]=array(
-'version'=>'2020021000', // *database version from which on this is expected
-'type'=>'query', // *can be: new_lang_item, new_admin_right, query
-'specs'=> array(
-    'query_code'=>'' // *for query: SQL statement to be executed. You can use "TABLE(tablename)" to have "or_" or the respective ORSEE table rpefix automatically prepended
-    )
-);
-
-END SAMPLE CODE
-*/
-
+include ("../config/dbupdates.php");
 
 ?>

--- a/tagsets/language.php
+++ b/tagsets/language.php
@@ -299,33 +299,35 @@ function lang__check_symbol_exists($symbol) {
     }
 }
 
-function lang__add_new_symbol($symbol,$terms) {
+function lang__add_new_symbol($specs) {
     $languages=get_languages();
-    $item=array('content_type'=>'lang','content_name'=>$symbol);
+    $item=array('content_type'=>'lang','content_name'=>$specs['content_name']);
+    if (isset($specs['content_type'])) {
+        $item['content_type']=$specs['content_type'];
+    }
+    
     foreach ($languages as $thislang) {
-        if(isset($terms[$thislang])) {
-            $item[$thislang]=$terms[$thislang];
-        } elseif(isset($terms['en'])) {
-            $item[$thislang]=$terms['en'];
+        if(isset($specs['content'][$thislang])) {
+            $item[$thislang]=$specs['content'][$thislang];
+        } elseif(isset($specs['content']['en'])) {
+            $item[$thislang]=$specs['content']['en'];
         } else {
-            $item[$thislang]=reset($terms);
+            $item[$thislang]=reset($specs['content']);
         }
     }
     $done=lang__insert_to_lang($item);
 }
 
-function lang__upgrade_symbol_if_not_exists($symbol,$terms) {
-    $symbol_exists=lang__check_symbol_exists($symbol);
+function lang__upgrade_symbol_if_not_exists($specs) {
+    $symbol_exists=lang__check_symbol_exists($specs['content_name']);
     if(!$symbol_exists) {
-        lang__add_new_symbol($symbol,$terms);
-        log__admin("Automatic upgrade: added language symbol '".$symbol."'.");
-        message("Automatic upgrade: added language symbol '".$symbol."'.");
+        lang__add_new_symbol($specs);
+        log__admin("Automatic database upgrade: added language symbol '".$specs['content_name']."'.");
         return true;
     } else {
         return false;
     }
 }
-
 
 function lang__reorganize_lang_table($steps=10000) {
 

--- a/tagsets/language.php
+++ b/tagsets/language.php
@@ -325,6 +325,7 @@ function lang__upgrade_symbol_if_not_exists($specs) {
         log__admin("Automatic database upgrade: added language symbol '".$specs['content_name']."'.");
         return true;
     } else {
+        log__admin("Automatic database upgrade: symbol '".$specs['content_name']."' not added because it alread exists.");
         return false;
     }
 }

--- a/tagsets/logfunctions.php
+++ b/tagsets/logfunctions.php
@@ -160,7 +160,7 @@ function log__show_log($log) {
     $query="SELECT * FROM ".$logtable.$secondtable."
         WHERE id IS NOT NULL ".
         $aquery.$idquery.$tquery.
-        " ORDER BY timestamp DESC
+        " ORDER BY timestamp DESC, log_id DESC 
         LIMIT :offset , :limit ";
     $result=or_query($query,$pars);
     $num_rows=pdo_num_rows($result);

--- a/tagsets/orsee_mysql.php
+++ b/tagsets/orsee_mysql.php
@@ -247,5 +247,39 @@ function dump_array($array,$title="",$dolang=true) {
     echo '</TABLE>';
 }
 
+function version_to_integer($version) {
+    $varray=explode(".",$version);
+    $version_int=$varray[0]*10000+$varray[1]*100+$varray[2]*1;
+    return $version_int;
+}
+
+function check_database_upgrade() {
+    global $settings, $system__version;
+
+    if (!isset($settings['database_version'])) {
+        $settings['database_version']='3.0.2';
+    }
+    $current_system_version_int=version_to_integer($system__version);
+    $db_version_int=version_to_integer($settings['database_version']);
+    if ($db_version_int<$current_system_version_int) {
+        $done=or_upgrade_database($old_db_version_int);
+        $done=orsee_db_save_array(array('option_value'=>$system__version),'options',1,'option_id');
+        return $done;
+    } else {
+        return false;
+    }
+}
+
+function or_upgrade_database($old_version_int) {
+    global $settings;
+    if ($old_version<30003) {
+        if (!isset($settings['database_version'])) {
+            $done=or_query("INSERT INTO ".table('or_options')." VALUES (1,'general',NULL,'database_version','3.0.3')");
+        }
+    }
+    
+    // further database upgrade, to be added with each new ORSEE version if necessary
+
+}
 
 ?>

--- a/tagsets/orsee_mysql.php
+++ b/tagsets/orsee_mysql.php
@@ -251,10 +251,10 @@ function check_database_upgrade() {
     global $settings, $system__database_version;
 
     if (!isset($settings['database_version'])) {
-        $settings['database_version']='2017112700';
+        $settings['database_version']=0;
         $done=or_query("INSERT INTO ".table('options')." VALUES (1,'general',NULL,'database_version','".$settings['database_version']."')");
     }
-    if ($settings['database_version']<$system__database_version) {
+    if ((int)$settings['database_version']<$system__database_version) {
         $done=or_upgrade_database();
         return $done;
     } else {
@@ -264,7 +264,7 @@ function check_database_upgrade() {
 
 function upgrade_database_version($new_version) {
     global $settings;
-    $settings['database_version']=$new_version;
+    $settings['database_version']=(int)$new_version;
     $done=orsee_db_save_array(array('option_value'=>$new_version),'options',1,'option_id');
     if(!$done) log__admin("Database upgrade error. Could not set database version to new version number ".$new_version."!");
     return $done;
@@ -300,7 +300,7 @@ function or_upgrade_database() {
     // run the updates, stop if there is an error
     $continue=true;
     foreach ($database_upgrades as $this_version=>$vupgrades) {
-        if ($this_version>$settings['database_version']) {
+        if ((int)$this_version>(int)$settings['database_version']) {
             foreach ($vupgrades as $upgr) {
                 if ($continue) {
                    if ($upgr['type']=='new_lang_item') {
@@ -320,7 +320,7 @@ function or_upgrade_database() {
                 }
             }
             if ($continue) {
-                $done=upgrade_database_version($this_version);
+                $done=upgrade_database_version((int)$this_version);
                 log__admin('Automatic database upgrade: Database upgraded to version '.$this_version.'.');
             }
         }


### PR DESCRIPTION
Revised previous approach.
- Database upgrades are now defined at the end of config/system.php as items in an array $system__database_upgrades.
- They can be of type "new_lang_item", "new_admin_right", or "query". Sample definition codes are provided in config/system.php.
- Upgrade functions are located in tagsets/orsee_mysql.php. Upgrade is only invoked if current database version (stored in MySQL or_options table) is lower than code database version (defined as $system__database_version on top of config/system.php).
- If upgrade is executed, then first the $system__database_upgrades is read in and syntax of all entries is checked. Upgrade is aborted if syntax is not ok.
Then the array $system__database_version is organized by version numbers.
- For each version number, the upgrades are executed consecutively. If a particular upgrade does not succeed, process is stopped (and will stop again and again at this point if issue is not fixed).
- When all upgrades for a particular version number succeeded, then database version number will be increased and upgrades for this version number will be ignored in the future.
- All upgrade successes and failures are logged into the admin log and can be followed in Statistics/Logs/Experimenter actions.
- Upgrade type new_lang_item: This adds a new term to the language table. This upgrade is graceful: it won't do anything if the term already exists, and it is not a big problem if the upgrade fails, since then simply the shortcut is displayed on the respective page and the item can be added manually in ORSEE. So this upgrade type typically won't throw any errors.
- Upgrade type new_admin_right: This adds the default rights to specified admin types for a new admin right. This upgrade is graceful: it won't do anything if the right is not defined in $system__admin_rights or if the right is already defined for any admin usertype, and it is not a big problem if the upgrade fails, since then the right can simply be manually enabled for the different admin usertypes. So this upgrade type typically won't throw any errors.
- Upgrade type query: This executes a query into the ORSEE MySQL database. Currently there is no use case for this, yet. (It is expected that major database structure manipulations in ORSEE will result in a major new version and require reinstallation and data import.) If the query fails, the upgrade procedure will be aborted. Since the table() function to prefix (e.g. or_) a table name is not available yet upon definition of $system__database_upgrades in config/system.php, the query can use the syntax TABLE(tablename) which will automatically replaced by the prefixed tablename before execution.