### PR TITLE
Bugfix: 404 upon redirection after login

### DIFF
--- a/admin/admin_login.php
+++ b/admin/admin_login.php
@@ -22,13 +22,13 @@ if ($proceed) {
         if ($logged_in) {
             $expadmindata['admin_id']=$_SESSION['expadmindata']['admin_id'];
             log__admin("login");
-            if (isset($_REQUEST['requested_url']) && $_REQUEST['requested_url']) redirect($_REQUEST['requested_url']);
+            if (isset($_REQUEST['requested_url']) && $_REQUEST['requested_url']) redirect(urldecode($_REQUEST['requested_url']));
             else redirect("admin/index.php");
         } else {
             message(lang('error_password_or_username'));
             $add="";
             if (isset($_REQUEST['requested_url']) && $_REQUEST['requested_url'])
-                $add="?requested_url=".urlencode($_REQUEST['requested_url']);
+                $add="?requested_url=".$_REQUEST['requested_url'];
             redirect("admin/admin_login.php".$add);
         }
         $proceed=false;


### PR DESCRIPTION
A previous security bugfix used urlencode() to sanitize a URL (to redirect to after admin login) in the admin form. However, this let to a double encoding when submitted, and a still urlencoded URL when attempting redirection, resulting in a 404 error when redirecting after an admin logged in. This fix decodes the URL before redirecting.