### PR TITLE
Feature: SSL support for MySQL connection

### DIFF
--- a/install/settings-dist.php
+++ b/install/settings-dist.php
@@ -34,6 +34,18 @@ $site__database_admin_password="orsee_pw";
 $site__database_type="mysql";
 $site__database_table_prefix="or_";
 
+// SSL mysql connection. Works with PHP >=5.3.9.
+// Use only if your database is located on a different server 
+// and you want to connect via SSL encrypted connection to it
+$site__database_use_ssl=false;
+// path name of client private key file
+$site__database_ssl_key='/etc/mysql/ssl/client-key.pem'; 
+// path name of  client public key certificate file
+$site__database_ssl_cert='/etc/mysql/ssl/client-cert.pem';
+// path name of Certificate Authority (CA) certificate file. 
+// if used, must be the same on client and server
+$site__database_ssl_ca='/etc/mysql/ssl/ca-cert.pem';
+
 // TIMEZOME SETTING
 // PHP >= 5.1.0 requires the timezone to be explicitely set.
 // If you have not set it in php.ini, then set it here. (Otherwise, you can uncomment.)

--- a/tagsets/orsee_mysql.php
+++ b/tagsets/orsee_mysql.php
@@ -31,6 +31,18 @@ function site__database_config() {
 
     $dsn='mysql:'.$host.$port.$charset.$dbname;
 
+    if (isset($site__database_use_ssl) && $site__database_use_ssl) {
+        if ($site__database_ssl_key) {
+            $construct_options[PDO::MYSQL_ATTR_SSL_KEY]=$site__database_ssl_key;
+        }
+        if ($site__database_ssl_cert) {
+            $construct_options[PDO::MYSQL_ATTR_SSL_CERT]=$site__database_ssl_cert;
+        }
+        if ($site__database_ssl_ca) {
+            $construct_options[PDO::MYSQL_ATTR_SSL_CA]=$site__database_ssl_ca;
+        }
+    }
+
     try {
         $db = new PDO($dsn, $site__database_admin_username, $site__database_admin_password,$construct_options);
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
This adds SSL support for the connection to the MySQL databse. This is only relevant if the MySQL database is located on a different server than ORSEE/the webserver. SSL is supported in PHP's mysql_pdo from version 5.3.9. Do not forget to update your conf/settings.php file.