### PR TITLE
Feature: Hide columns in result lists cond. on admin type

### DIFF
--- a/admin/options_ordered_lists.php
+++ b/admin/options_ordered_lists.php
@@ -23,62 +23,52 @@ if ($proceed) {
         $header=lang('columns_in_search_results_table_for_active_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_search_all') {
         $header=lang('columns_in_search_results_table_for_all_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_assign') {
         $header=lang('columns_in_results_table_for_assign_query');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_search_duplicates') {
         $header=lang('columns_in_search_results_table_for_profile_duplicates');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_search_unconfirmed') {
         $header=lang('columns_in_search_results_table_for_unconfirmed_profiles');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array();
     } elseif ($list=='experiment_assigned_list') {
         $header=lang('columns_in_list_of_assigned_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='session_participants_list') {
         $header=lang('columns_in_session_participants_list');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='session_participants_list_pdf') {
         $header=lang('columns_in_pdf_session_participants_list');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='email_participant_guesses_list') {
         $header=lang('email_module_participant_guesses_list');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_option='sortby_radio';
-        $list_add_option_name=lang('sort_table_by');
+        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='anonymize_profile_list') {
         $header=lang('fields_to_anonymize_in_anonymization_bulk_action');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_anonymization_fields_edit';
-        $list_add_option='field_value';
-        $list_add_option_name=lang('anonymized_dummy_value');
+        $list_add_options=array('field_value'=>lang('anonymized_dummy_value'));
         $button_text=lang('save');
     }
     if (!isset($cols)) redirect ('admin/options_main.php');
@@ -93,15 +83,11 @@ if ($proceed) {
         if(isset($_REQUEST['item_order']) && is_array($_REQUEST['item_order']) && count($_REQUEST['item_order'])>0) {
             $details=array();
             if (isset($_REQUEST['sortby']) && $_REQUEST['sortby']) {
-                $details=array(trim($_REQUEST['sortby'])=>array('default_sortby'=>1));
+                $details[trim($_REQUEST['sortby'])]['default_sortby']=1;
             }
             if (isset($_REQUEST['field_values']) && $_REQUEST['field_values'] && is_array($_REQUEST['field_values'])) {
                 foreach ($_REQUEST['field_values'] as $field=>$field_value) {
-                    if (isset($details[$field])) {
-                        $details[$field]['field_value']=$field_value;
-                    } else {
-                        $details[$field]=array('field_value'=>$field_value);
-                    }
+                    $details[$field]['field_value']=$field_value;
                 }
             }
             $done=options__save_item_order($list,$_REQUEST['item_order'],$details);
@@ -124,10 +110,13 @@ if ($proceed) {
         $rows[$line['item_name']]=$line;
     }
 
-    if ($list_add_option)  {
-        $listrows=options__ordered_lists_get_current($cols,$rows,$list_add_option);
+    if (isset($list_add_options) && is_array($list_add_options) && count($list_add_options)>0)  {
+        $listrows=options__ordered_lists_get_current($cols,$rows,$list_add_options);
         $headers='<TD></TD><TD align="center">'.str_replace(" ","<BR>",lang('sort_table_by')).'</TD>';
-        $headers='<TD></TD><TD align="center">'.$list_add_option_name.'</TD>';
+        $headers='<TD></TD>';
+        foreach ($list_add_options as $name=>$display_name) {
+            $headers.='<TD align="center">'.$display_name.'</TD>';
+        }
     } else {
         $listrows=options__ordered_lists_get_current($cols,$rows);
         $headers='';

--- a/admin/options_ordered_lists.php
+++ b/admin/options_ordered_lists.php
@@ -23,17 +23,17 @@ if ($proceed) {
         $header=lang('columns_in_search_results_table_for_active_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_search_all') {
         $header=lang('columns_in_search_results_table_for_all_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_assign') {
         $header=lang('columns_in_results_table_for_assign_query');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='result_table_search_duplicates') {
         $header=lang('columns_in_search_results_table_for_profile_duplicates');
         $cols=participant__get_possible_participant_columns($list);
@@ -43,22 +43,22 @@ if ($proceed) {
         $header=lang('columns_in_search_results_table_for_unconfirmed_profiles');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array();
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'));
     } elseif ($list=='experiment_assigned_list') {
         $header=lang('columns_in_list_of_assigned_participants');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='session_participants_list') {
         $header=lang('columns_in_session_participants_list');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='session_participants_list_pdf') {
         $header=lang('columns_in_pdf_session_participants_list');
         $cols=participant__get_possible_participant_columns($list);
         $allow_check='pform_results_lists_edit';
-        $list_add_options=array('sortby_radio'=>lang('sort_table_by'));
+        $list_add_options=array('hide_for_admin_types'=>lang('hide_column_for_admin_types'),'sortby_radio'=>lang('sort_table_by'));
     } elseif ($list=='email_participant_guesses_list') {
         $header=lang('email_module_participant_guesses_list');
         $cols=participant__get_possible_participant_columns($list);
@@ -90,6 +90,22 @@ if ($proceed) {
                     $details[$field]['field_value']=$field_value;
                 }
             }
+            if (isset($_REQUEST['hide_admin_types']) && $_REQUEST['hide_admin_types'] && is_array($_REQUEST['hide_admin_types'])) {
+                $admin_types=admin__load_admin_types();
+                foreach ($_REQUEST['hide_admin_types'] as $field=>$field_value) {
+                    $type_array=explode(",",$field_value); 
+                    $ftype_array=array();
+                    foreach ($type_array as $k=>$v) {
+                        $v=trim($v);
+                        if (isset($admin_types[$v])) {
+                            $ftype_array[]=$v;
+                        }
+                    }
+                    sort($ftype_array);
+                    $field_value=implode(",",$ftype_array);
+                    $details[$field]['hide_admin_types']=$field_value;
+                }
+            }
             $done=options__save_item_order($list,$_REQUEST['item_order'],$details);
             message(lang('changes_saved'));
             redirect('admin/options_ordered_lists.php?list='.urlencode($list));
@@ -112,10 +128,21 @@ if ($proceed) {
 
     if (isset($list_add_options) && is_array($list_add_options) && count($list_add_options)>0)  {
         $listrows=options__ordered_lists_get_current($cols,$rows,$list_add_options);
-        $headers='<TD></TD><TD align="center">'.str_replace(" ","<BR>",lang('sort_table_by')).'</TD>';
         $headers='<TD></TD>';
         foreach ($list_add_options as $name=>$display_name) {
-            $headers.='<TD align="center">'.$display_name.'</TD>';
+            if ($name=='hide_for_admin_types') {
+                $admin_types=admin__load_admin_types();
+                $admin_types_arr=array();
+                foreach($admin_types as $k=>$line) {
+                    $admin_types_arr[]=$k;
+                }
+                $admin_types_list=implode(", ",$admin_types_arr);
+                $headers.='<TD align="center" width="30%">'.$display_name;
+                $headers.='<BR><FONT class="small">'.lang('enter_comma_separated_list_of_any_of').' '.$admin_types_list.'<FONT>';
+                $headers.='</TD>';
+            } else {
+                $headers.='<TD align="center">'.$display_name.'</TD>';
+            }
         }
     } else {
         $listrows=options__ordered_lists_get_current($cols,$rows);

--- a/config/dbupdates.php
+++ b/config/dbupdates.php
@@ -178,5 +178,35 @@ $system__database_upgrades[]=array(
     )
 );
 
+$system__database_upgrades[]=array(
+    'version'=>'2020021300',
+    'type'=>'new_lang_item', 
+    'specs'=> array(
+        'content_name'=>'hide_column_for_admin_types', 
+        'content_type'=>'lang',
+        'content'=>array('en'=>'Hide this column for admin types','de'=>'Diese Spalte verbergen für Admin-Typen')
+    )
+);
+
+$system__database_upgrades[]=array(
+    'version'=>'2020021300',
+    'type'=>'new_lang_item', 
+    'specs'=> array(
+        'content_name'=>'enter_comma_separated_list_of_any_of', 
+        'content_type'=>'lang',
+        'content'=>array('en'=>'Enter comma seperated list of any of these types:','de'=>'Geben Sie eine komma-separierte Liste aus folgenden Typen ein:')
+    )
+);
+
+$system__database_upgrades[]=array(
+    'version'=>'2020021300',
+    'type'=>'new_lang_item', 
+    'specs'=> array(
+        'content_name'=>'hidden_data_symbol', 
+        'content_type'=>'lang',
+        'content'=>array('en'=>'***','de'=>'***')
+    )
+);
+
 
 ?>

--- a/tagsets/expadmin.php
+++ b/tagsets/expadmin.php
@@ -212,6 +212,54 @@ function admin__select_admin_type($fieldname,$selected="",$return_var="type_name
     return $out;
 }
 
+function admin__load_admin_types() {
+    global $settings, $preloaded_admintypes;
+    if (!isset($preloaded_admintypes) || !is_array($preloaded_admintypes)) {
+        $preloaded_admintypes=array();
+        $query="SELECT * from ".table('admin_types')."
+                 ORDER by type_name";
+        $result=or_query($query);
+        while ($line=pdo_fetch_assoc($result)) {
+            $preloaded_admintypes[$line['type_name']]=$line;
+        }
+    }
+    return $preloaded_admintypes;
+}
+
+function admin__admin_type_select_field($postvarname,$selected,$multi=true,$mpoptions=array()) {
+    // $postvarname - name of form field
+    // selected - array of pre-selected class ids
+    global $lang;
+    $out="";
+    if (!is_array($mpoptions)) $mpoptions=array();
+    $default_options=array('cols'=>30,'picker_maxnumcols'=>3);
+    foreach ($default_options as $k=>$v) {
+        if (!isset($mpoptions[$k])) {
+            $mpoptions[$k]=$v;
+        }
+    }
+    $admin_types=admin__load_admin_types();
+    $mylist=array();
+    foreach ($admin_types as $k=>$line) {
+        $mylist[$k]=$k;
+    }
+    if ($multi) {
+        $out.= get_multi_picker($postvarname,$mylist,$selected,$mpoptions);
+    } else {
+        $out.= '<SELECT name="'.$postvarname.'">
+                <OPTION value=""'; if (!$selected) $out.= ' SELECTED'; $out.= '>-</OPTION>
+                ';
+        foreach ($mylist as $k=>$v) {
+            $out.= '<OPTION value="'.$k.'"';
+                if ($selected==$k) $out.= ' SELECTED'; $out.= '>'.$v.'</OPTION>
+                ';
+        }
+        $out.= '</SELECT>
+        ';
+    }
+    return $out;
+}
+
 function admin__update_admin_rights_if_not_exists($specs) {
     global $system__admin_rights;
     $done=false;

--- a/tagsets/options.php
+++ b/tagsets/options.php
@@ -188,7 +188,7 @@ function options__save_item_order($item_type,$order_array,$details=array()) {
     return $done;
 }
 
-function options__ordered_lists_get_current($poss_cols,$saved_cols,$extra_field='') {
+function options__ordered_lists_get_current($poss_cols,$saved_cols,$extra_fields=array()) {
     // filter out non-draggable at begin and end
     $first_draggable=false;
     $first=array(); $num_first=0; $last=array(); $num_last=0;
@@ -257,14 +257,20 @@ function options__ordered_lists_get_current($poss_cols,$saved_cols,$extra_field=
         if (!isset($arr['fixed_position'])) $arr['fixed_position']=0;
         if (!isset($arr['sortable'])) $arr['sortable']=true;
         if (!isset($arr['cols'])) $arr['cols']='<TD>'.$arr['display_text'].'</TD>';
-        if ($extra_field && $extra_field=='sortby_radio') {
-            if ($arr['sortable']) {
-                $arr['cols'].='<TD><INPUT type="radio" name="sortby" value="'.$k.'"';
-                if (isset($arr['item_details']['default_sortby']) && $arr['item_details']['default_sortby']) $arr['cols'].=' CHECKED';
-                $arr['cols'].='></TD>';
-            } else $arr['cols'].='<TD></TD>';
-        } elseif ($extra_field && $extra_field=='field_value') {
-            $arr['cols'].='<TD><INPUT type="text" size="30" maxlength="255" name="field_values['.$k.']" value="'.$arr['item_details']['field_value'].'"></TD>';
+        foreach ($extra_fields as $extra_field=>$display_name) {
+            if ($extra_field=='sortby_radio') {
+                if ($arr['sortable']) {
+                    $arr['cols'].='<TD><INPUT type="radio" name="sortby" value="'.$k.'"';
+                    if (isset($arr['item_details']['default_sortby']) && $arr['item_details']['default_sortby']) {
+                        $arr['cols'].=' CHECKED';
+                    }
+                    $arr['cols'].='></TD>';
+                } else {
+                    $arr['cols'].='<TD></TD>';
+                }
+            } elseif ($extra_field=='field_value') {
+                $arr['cols'].='<TD><INPUT type="text" size="30" maxlength="255" name="field_values['.$k.']" value="'.$arr['item_details']['field_value'].'"></TD>';
+            }
         }
         $listrows[$k]=$arr;
     }

--- a/tagsets/options.php
+++ b/tagsets/options.php
@@ -260,7 +260,7 @@ function options__ordered_lists_get_current($poss_cols,$saved_cols,$extra_fields
         foreach ($extra_fields as $extra_field=>$display_name) {
             if ($extra_field=='sortby_radio') {
                 if ($arr['sortable']) {
-                    $arr['cols'].='<TD><INPUT type="radio" name="sortby" value="'.$k.'"';
+                    $arr['cols'].='<TD align="center"><INPUT type="radio" name="sortby" value="'.$k.'"';
                     if (isset($arr['item_details']['default_sortby']) && $arr['item_details']['default_sortby']) {
                         $arr['cols'].=' CHECKED';
                     }
@@ -269,7 +269,25 @@ function options__ordered_lists_get_current($poss_cols,$saved_cols,$extra_fields
                     $arr['cols'].='<TD></TD>';
                 }
             } elseif ($extra_field=='field_value') {
+                if (!isset($arr['item_details'])) {
+                    $arr['item_details']=array();
+                }
+                if (!isset($arr['item_details']['field_value'])) {
+                    $arr['item_details']['field_value']='';
+                }
                 $arr['cols'].='<TD><INPUT type="text" size="30" maxlength="255" name="field_values['.$k.']" value="'.$arr['item_details']['field_value'].'"></TD>';
+            } elseif ($extra_field=='hide_for_admin_types') {
+                if (!(isset($arr['disallow_hide']) && $arr['disallow_hide'])) {
+                    if (!isset($arr['item_details'])) {
+                        $arr['item_details']=array();
+                    }
+                    if (!isset($arr['item_details']['hide_admin_types'])) {
+                        $arr['item_details']['hide_admin_types']='';
+                    }
+                    $arr['cols'].='<TD><INPUT type="text" size="30" maxlength="255" name="hide_admin_types['.$k.']" value="'.$arr['item_details']['hide_admin_types'].'"></TD>';
+                } else {
+                    $arr['cols'].='<TD></TD>';
+                }
             }
         }
         $listrows[$k]=$arr;

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -1499,164 +1499,160 @@ function participant__get_result_table_row($columns,$p) {
         if (in_array($expadmindata['admin_type'],$hide_for_admin_types)) {
             $out.='<td class="small">'.lang('hidden_data_symbol').'</td>';
         } else {
-        // THE SWITCH CLAUSE BELOW NEEDS TO BE INDENTED. I WILL DO THIS LATER, 
-        // SINCE IT COMPLETELY SCREWS UP THE GIT DIFF AND MAKES IT LOOK AS IF 
-        // THERE WERE MANY CHANGES TO IT - AND THERE ARE NOT
-        switch($k) {
-            case 'email_unconfirmed':
-                $message="";
-                $message=experimentmail__get_confirmation_mail_text($p);
-                $message=str_replace(" ","%20",$message);
-                $message=str_replace("\n\m","\n",$message);
-                $message=str_replace("\m\n","\n",$message);
-                $message=str_replace("\m","\n",$message);
-                $message=str_replace("\n","%0D%0A",$message);
-                $linktext='mailto:'.$p['email'].'?subject='.str_replace(" ","%20",lang('registration_email_subject')).'&reply-to='.urlencode($settings['support_mail']).'&body='.$message;
-                $out.='<td class="small">';
-                $out.='<A class="small" HREF="'.$linktext.'">'.$p['email'].'</A>';
-                $out.='</td>';
-                break;
-            case 'checkbox':
-                $out.='<td class="small">';
-                $out.='<INPUT type="checkbox" name="sel['.$p['participant_id'].']" value="y"';
-                if (isset($_REQUEST['sel'][$p['participant_id']]) && $_REQUEST['sel'][$p['participant_id']]=='y') $out.=' CHECKED';
-                elseif (isset($_SESSION['sel'][$p['participant_id']]) && $_SESSION['sel'][$p['participant_id']]=='y') $out.=' CHECKED';
-                $out.='></td>';
-                break;
-            case 'number_noshowup':
-                $out.='<td class="small">';
-                $out.=$p['number_noshowup'].'/'.$p['number_reg'];
-                $out.='</td>';
-                break;
-            case 'invited':
-                $out.='<td class="small">'.($p['invited']?lang('y'):lang('n')).'</td>';
-                break;
-            case 'rules_signed':
-                if ($settings['enable_rules_signed_tracking']=='y')  {
+            switch($k) {
+                case 'email_unconfirmed':
+                    $message="";
+                    $message=experimentmail__get_confirmation_mail_text($p);
+                    $message=str_replace(" ","%20",$message);
+                    $message=str_replace("\n\m","\n",$message);
+                    $message=str_replace("\m\n","\n",$message);
+                    $message=str_replace("\m","\n",$message);
+                    $message=str_replace("\n","%0D%0A",$message);
+                    $linktext='mailto:'.$p['email'].'?subject='.str_replace(" ","%20",lang('registration_email_subject')).'&reply-to='.urlencode($settings['support_mail']).'&body='.$message;
                     $out.='<td class="small">';
-                    $out.='<INPUT type="checkbox" name="rules['.$p['participant_id'].']" value="y"';
-                    if ($p['rules_signed']=='y') {
-                        $out.=' CHECKED';
-                    }
+                    $out.='<A class="small" HREF="'.$linktext.'">'.$p['email'].'</A>';
+                    $out.='</td>';
+                    break;
+                case 'checkbox':
+                    $out.='<td class="small">';
+                    $out.='<INPUT type="checkbox" name="sel['.$p['participant_id'].']" value="y"';
+                    if (isset($_REQUEST['sel'][$p['participant_id']]) && $_REQUEST['sel'][$p['participant_id']]=='y') $out.=' CHECKED';
+                    elseif (isset($_SESSION['sel'][$p['participant_id']]) && $_SESSION['sel'][$p['participant_id']]=='y') $out.=' CHECKED';
                     $out.='></td>';
-                }
-                break;
-            case 'subscriptions':
-                $exptypes=load_external_experiment_types();
-                $inv_arr=db_string_to_id_array($p[$k]);
-                $inv_names=array();
-                foreach($inv_arr as $inv) {
-                    if (isset($exptypes[$inv]['exptype_name'])) $inv_names[]=$exptypes[$inv]['exptype_name'];
-                    else $inv_names[]='undefined';
-                }
-                $out.='<td class="small">'.implode(", ",$inv_names).'</td>';
-                break;
-            case 'subpool_id':
-                $subpools=subpools__get_subpools();
-                $subpool_name=(isset($subpools[$p[$k]]['subpool_name']))?$subpools[$p[$k]]['subpool_name']:$p[$k];
-                $out.='<td class="small">'.$subpool_name.'</td>';
-                break;
-            case 'status_id':
-                $participant_statuses=participant_status__get_statuses();
-                $pstatus_name=(isset($participant_statuses[$p[$k]]['name']))?$participant_statuses[$p[$k]]['name']:$p[$k];
-                if ($participant_statuses[$p['status_id']]['eligible_for_experiments']=='y') $ccolor=$color['participant_status_eligible_for_experiments'];
-                else $ccolor=$color['participant_status_noneligible_for_experiments'];
-                $out.='<td class="small" bgcolor="'.$ccolor.'">'.$pstatus_name.'</td>';
-                break;
-            case 'edit_link':
-                if (check_allow('participants_edit')) $out.='<TD class="small">'.javascript__edit_popup_link($p['participant_id']).'</TD>';
-                break;
-            case 'creation_time':
-            case 'deletion_time':
-            case 'last_enrolment':
-            case 'last_profile_update':
-            case 'last_activity':
-            case 'last_login_attempt':
-                $out.='<td class="small">';
-                if ($p[$k]) $out.=ortime__format($p[$k],'hide_second:false');
-                else  $out.='-';
-                $out.='</td>';
-                break;
-            case 'session_id':
-                $out.='<td class="small">';
-                if (check_allow('experiment_edit_participants')) {
-                    $out.='<INPUT type=hidden name="orig_session['.$p['participant_id'].']" value="'.$p['session_id'].'">';
-                    $out.=select__sessions($p['session_id'],'session['.$p['participant_id'].']',$thislist_sessions,false);
-                } else $out.=session__build_name($thislist_sessions[$p['session_id']]);
-                $out.='</td>';
-                break;
-            case 'payment_budget':
-                if($settings['enable_payment_module']=='y') {
-                    $payment_budgets=payments__load_budgets();
-                    if (check_allow('payments_edit')) {
-                        $out.='<td class="small">';
-                        $out.=payments__budget_selectfield('paybudget['.$p['participant_id'].']',$p['payment_budget'],array(),$thislist_avail_payment_budgets);
-                        $out.='</td>';
-                    } elseif (check_allow('payments_view')) {
-                        $out.='<td class="small">';
-                        if (isset($payment_budgets[$p['payment_budget']])) $out.=$payment_budgets[$p['payment_budget']]['budget_name']; else $out.='-';
-                        $out.='</td>';
-                    }
-                }
-                break;
-            case 'payment_type':
-                if($settings['enable_payment_module']=='y') {
-                    $payment_types=payments__load_paytypes();
-                    if (check_allow('payments_edit')) {
-                        $out.='<td class="small">';
-                        $out.=payments__paytype_selectfield('paytype['.$p['participant_id'].']',$p['payment_type'],array(),$thislist_avail_payment_types);
-                        $out.='</td>';
-                    } elseif (check_allow('payments_view')) {
-                        $out.='<td class="small">';
-                        if (isset($payment_types[$p['payment_type']])) $out.=$payment_types[$p['payment_type']]; else $out.='-';
-                        $out.='</td>';
-                    }
-                }
-                break;
-            case 'payment_amount':
-                if($settings['enable_payment_module']=='y') {
-                    if (check_allow('payments_edit')) {
-                        $out.='<td class="small">';
-                        $out.='<INPUT type="text" name="payamt['.$p['participant_id'].']" value="';
-                        if ($p['payment_amt']!='') $out.=$p['payment_amt']; else $out.='0.00';
-                        $out.='" size="7" maxlength="10" style="text-align:right;">';
-                        $out.='</td>';
-                    } elseif (check_allow('payments_view')) {
-                        $out.='<td class="small">';
-                        if ($p['payment_amt']!='') $out.=$p['payment_amt']; else $out.='-';
-                        $out.='</td>';
-                    }
-                }
-                break;
-            case 'pstatus_id':
-                $out.='<td class="small">';
-                if (check_allow('experiment_edit_participants')) {
-                    $out.='<INPUT type=hidden name="orig_pstatus_id['.$p['participant_id'].']" value="'.$p['pstatus_id'].'">';
-                    $out.=expregister__participation_status_select_field('pstatus_id['.$p['participant_id'].']',$p['pstatus_id']);
-                } else {
-                    $pstatuses=expregister__get_participation_statuses();
-                    $out.=$pstatuses[$p['pstatus_id']]['internal_name'];
-                }
-                $out.='</td>';
-                break;
-            default:
-                if (isset($pform_columns[$k])) {
+                    break;
+                case 'number_noshowup':
                     $out.='<td class="small">';
-                    if($pform_columns[$k]['link_as_email_in_lists']=='y') $out.='<A class="small" HREF="mailto:'.$p[$k].'">';
-                    if(preg_match("/(radioline|select_list|select_lang|radioline_lang)/",$pform_columns[$k]['type'])) {
-                        if (isset($pform_columns[$k]['lang'][$p[$k]])) $out.=lang($pform_columns[$k]['lang'][$p[$k]]);
-                        else $out.=$p[$k];
-                    } else $out.=$p[$k];
-                    if($pform_columns[$k]['link_as_email_in_lists']=='y') $out.='</A>';
+                    $out.=$p['number_noshowup'].'/'.$p['number_reg'];
                     $out.='</td>';
-                } else {
+                    break;
+                case 'invited':
+                    $out.='<td class="small">'.($p['invited']?lang('y'):lang('n')).'</td>';
+                    break;
+                case 'rules_signed':
+                    if ($settings['enable_rules_signed_tracking']=='y')  {
+                        $out.='<td class="small">';
+                        $out.='<INPUT type="checkbox" name="rules['.$p['participant_id'].']" value="y"';
+                        if ($p['rules_signed']=='y') {
+                            $out.=' CHECKED';
+                        }
+                        $out.='></td>';
+                    }
+                    break;
+                case 'subscriptions':
+                    $exptypes=load_external_experiment_types();
+                    $inv_arr=db_string_to_id_array($p[$k]);
+                    $inv_names=array();
+                    foreach($inv_arr as $inv) {
+                        if (isset($exptypes[$inv]['exptype_name'])) $inv_names[]=$exptypes[$inv]['exptype_name'];
+                        else $inv_names[]='undefined';
+                    }
+                    $out.='<td class="small">'.implode(", ",$inv_names).'</td>';
+                    break;
+                case 'subpool_id':
+                    $subpools=subpools__get_subpools();
+                    $subpool_name=(isset($subpools[$p[$k]]['subpool_name']))?$subpools[$p[$k]]['subpool_name']:$p[$k];
+                    $out.='<td class="small">'.$subpool_name.'</td>';
+                    break;
+                case 'status_id':
+                    $participant_statuses=participant_status__get_statuses();
+                    $pstatus_name=(isset($participant_statuses[$p[$k]]['name']))?$participant_statuses[$p[$k]]['name']:$p[$k];
+                    if ($participant_statuses[$p['status_id']]['eligible_for_experiments']=='y') $ccolor=$color['participant_status_eligible_for_experiments'];
+                    else $ccolor=$color['participant_status_noneligible_for_experiments'];
+                    $out.='<td class="small" bgcolor="'.$ccolor.'">'.$pstatus_name.'</td>';
+                    break;
+                case 'edit_link':
+                    if (check_allow('participants_edit')) $out.='<TD class="small">'.javascript__edit_popup_link($p['participant_id']).'</TD>';
+                    break;
+                case 'creation_time':
+                case 'deletion_time':
+                case 'last_enrolment':
+                case 'last_profile_update':
+                case 'last_activity':
+                case 'last_login_attempt':
                     $out.='<td class="small">';
-                    if (isset($p[$k])) $out.=$p[$k];
-                    else $out.='???';
+                    if ($p[$k]) $out.=ortime__format($p[$k],'hide_second:false');
+                    else  $out.='-';
                     $out.='</td>';
-                }
-        }
-        // END SWITCH
+                    break;
+                case 'session_id':
+                    $out.='<td class="small">';
+                    if (check_allow('experiment_edit_participants')) {
+                        $out.='<INPUT type=hidden name="orig_session['.$p['participant_id'].']" value="'.$p['session_id'].'">';
+                        $out.=select__sessions($p['session_id'],'session['.$p['participant_id'].']',$thislist_sessions,false);
+                    } else $out.=session__build_name($thislist_sessions[$p['session_id']]);
+                    $out.='</td>';
+                    break;
+                case 'payment_budget':
+                    if($settings['enable_payment_module']=='y') {
+                        $payment_budgets=payments__load_budgets();
+                        if (check_allow('payments_edit')) {
+                            $out.='<td class="small">';
+                            $out.=payments__budget_selectfield('paybudget['.$p['participant_id'].']',$p['payment_budget'],array(),$thislist_avail_payment_budgets);
+                            $out.='</td>';
+                        } elseif (check_allow('payments_view')) {
+                            $out.='<td class="small">';
+                            if (isset($payment_budgets[$p['payment_budget']])) $out.=$payment_budgets[$p['payment_budget']]['budget_name']; else $out.='-';
+                            $out.='</td>';
+                        }
+                    }
+                    break;
+                case 'payment_type':
+                    if($settings['enable_payment_module']=='y') {
+                        $payment_types=payments__load_paytypes();
+                        if (check_allow('payments_edit')) {
+                            $out.='<td class="small">';
+                            $out.=payments__paytype_selectfield('paytype['.$p['participant_id'].']',$p['payment_type'],array(),$thislist_avail_payment_types);
+                            $out.='</td>';
+                        } elseif (check_allow('payments_view')) {
+                            $out.='<td class="small">';
+                            if (isset($payment_types[$p['payment_type']])) $out.=$payment_types[$p['payment_type']]; else $out.='-';
+                            $out.='</td>';
+                        }
+                    }
+                    break;
+                case 'payment_amount':
+                    if($settings['enable_payment_module']=='y') {
+                        if (check_allow('payments_edit')) {
+                            $out.='<td class="small">';
+                            $out.='<INPUT type="text" name="payamt['.$p['participant_id'].']" value="';
+                            if ($p['payment_amt']!='') $out.=$p['payment_amt']; else $out.='0.00';
+                            $out.='" size="7" maxlength="10" style="text-align:right;">';
+                            $out.='</td>';
+                        } elseif (check_allow('payments_view')) {
+                            $out.='<td class="small">';
+                            if ($p['payment_amt']!='') $out.=$p['payment_amt']; else $out.='-';
+                            $out.='</td>';
+                        }
+                    }
+                    break;
+                case 'pstatus_id':
+                    $out.='<td class="small">';
+                    if (check_allow('experiment_edit_participants')) {
+                        $out.='<INPUT type=hidden name="orig_pstatus_id['.$p['participant_id'].']" value="'.$p['pstatus_id'].'">';
+                        $out.=expregister__participation_status_select_field('pstatus_id['.$p['participant_id'].']',$p['pstatus_id']);
+                    } else {
+                        $pstatuses=expregister__get_participation_statuses();
+                        $out.=$pstatuses[$p['pstatus_id']]['internal_name'];
+                    }
+                    $out.='</td>';
+                    break;
+                default:
+                    if (isset($pform_columns[$k])) {
+                        $out.='<td class="small">';
+                        if($pform_columns[$k]['link_as_email_in_lists']=='y') $out.='<A class="small" HREF="mailto:'.$p[$k].'">';
+                        if(preg_match("/(radioline|select_list|select_lang|radioline_lang)/",$pform_columns[$k]['type'])) {
+                            if (isset($pform_columns[$k]['lang'][$p[$k]])) $out.=lang($pform_columns[$k]['lang'][$p[$k]]);
+                            else $out.=$p[$k];
+                        } else $out.=$p[$k];
+                        if($pform_columns[$k]['link_as_email_in_lists']=='y') $out.='</A>';
+                        $out.='</td>';
+                    } else {
+                        $out.='<td class="small">';
+                        if (isset($p[$k])) $out.=$p[$k];
+                        else $out.='???';
+                        $out.='</td>';
+                    }
+            }
         }
     }
     return $out;
@@ -1678,83 +1674,79 @@ function participant__get_result_table_row_pdf($columns,$p) {
         if (in_array($expadmindata['admin_type'],$hide_for_admin_types)) {
             $row[]=lang('hidden_data_symbol');
         } else {
-        // THE SWITCH CLAUSE BELOW NEEDS TO BE INDENTED. I WILL DO THIS LATER, 
-        // SINCE IT COMPLETELY SCREWS UP THE GIT DIFF AND MAKES IT LOOK AS IF 
-        // THERE WERE MANY CHANGES TO IT - AND THERE ARE NOT
-        switch($k) {
-            case 'number_noshowup':
-                $row[]=$p['number_noshowup'].'/'.$p['number_reg'];
-                break;
-            case 'rules_signed':
-                if ($settings['enable_rules_signed_tracking']=='y')  {
-                    $row[]= ($p['rules_signed']!='y') ? "X" : '';
-                }
-                break;
-            case 'subscriptions':
-                $exptypes=load_external_experiment_types();
-                $inv_arr=db_string_to_id_array($p[$k]);
-                $inv_names=array();
-                foreach($inv_arr as $inv) {
-                    if (isset($exptypes[$inv]['exptype_name'])) $inv_names[]=$exptypes[$inv]['exptype_name'];
-                    else $inv_names[]='undefined';
-                }
-                $row[]=implode(", ",$inv_names);
-                break;
-            case 'subpool_id':
-                $subpools=subpools__get_subpools();
-                $subpool_name=(isset($subpools[$p[$k]]['subpool_name']))?$subpools[$p[$k]]['subpool_name']:$p[$k];
-                $row[]=$subpool_name;
-                break;
-            case 'status_id':
-                $participant_statuses=participant_status__get_statuses();
-                $pstatus_name=(isset($participant_statuses[$p[$k]]['name']))?$participant_statuses[$p[$k]]['name']:$p[$k];
-                $row[]=$pstatus_name;
-                break;
-            case 'creation_time':
-            case 'deletion_time':
-            case 'last_enrolment':
-            case 'last_profile_update':
-            case 'last_activity':
-            case 'last_login_attempt':
-                if ($p[$k]) $row[]=ortime__format($p[$k],'hide_second:false');
-                else  $row[]='-';
-                break;
-            case 'session_id':
-                $row[]=session__build_name($thislist_sessions[$p['session_id']]);
-                break;
-            case 'payment_budget':
-                if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
-                    $payment_budgets=payments__load_budgets();
-                    if (isset($payment_budgets[$p['payment_budget']])) $row[]=$payment_budgets[$p['payment_budget']]['budget_name']; else $row[]='-';
-                }
-                break;
-            case 'payment_type':
-                if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
-                    $payment_types=payments__load_paytypes();
-                    if (isset($payment_types[$p['payment_type']])) $row[]=$payment_types[$p['payment_type']]; else $row[]='-';
-                }
-                break;
-            case 'payment_amount':
-                if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
-                    if ($p['payment_amt']!='') $row[]=$p['payment_amt']; else $row[]='-';
-                }
-                break;
-            case 'pstatus_id':
-                $pstatuses=expregister__get_participation_statuses();
-                $row[]=$pstatuses[$p['pstatus_id']]['internal_name'];
-                break;
-            default:
-                if (isset($pform_columns[$k])) {
-                    if(preg_match("/(radioline|select_list|select_lang|radioline_lang)/",$pform_columns[$k]['type'])) {
-                        if (isset($pform_columns[$k]['lang'][$p[$k]])) $row[]=lang($pform_columns[$k]['lang'][$p[$k]]);
-                        else $row[]=$p[$k];
-                    } else $row[]=$p[$k];
-                } else {
-                    if (isset($p[$k])) $row[]=$p[$k];
-                    else $row[]='???';
-                }
-        }
-        // END SWITCH
+            switch($k) {
+                case 'number_noshowup':
+                    $row[]=$p['number_noshowup'].'/'.$p['number_reg'];
+                    break;
+                case 'rules_signed':
+                    if ($settings['enable_rules_signed_tracking']=='y')  {
+                        $row[]= ($p['rules_signed']!='y') ? "X" : '';
+                    }
+                    break;
+                case 'subscriptions':
+                    $exptypes=load_external_experiment_types();
+                    $inv_arr=db_string_to_id_array($p[$k]);
+                    $inv_names=array();
+                    foreach($inv_arr as $inv) {
+                        if (isset($exptypes[$inv]['exptype_name'])) $inv_names[]=$exptypes[$inv]['exptype_name'];
+                        else $inv_names[]='undefined';
+                    }
+                    $row[]=implode(", ",$inv_names);
+                    break;
+                case 'subpool_id':
+                    $subpools=subpools__get_subpools();
+                    $subpool_name=(isset($subpools[$p[$k]]['subpool_name']))?$subpools[$p[$k]]['subpool_name']:$p[$k];
+                    $row[]=$subpool_name;
+                    break;
+                case 'status_id':
+                    $participant_statuses=participant_status__get_statuses();
+                    $pstatus_name=(isset($participant_statuses[$p[$k]]['name']))?$participant_statuses[$p[$k]]['name']:$p[$k];
+                    $row[]=$pstatus_name;
+                    break;
+                case 'creation_time':
+                case 'deletion_time':
+                case 'last_enrolment':
+                case 'last_profile_update':
+                case 'last_activity':
+                case 'last_login_attempt':
+                    if ($p[$k]) $row[]=ortime__format($p[$k],'hide_second:false');
+                    else  $row[]='-';
+                    break;
+                case 'session_id':
+                    $row[]=session__build_name($thislist_sessions[$p['session_id']]);
+                    break;
+                case 'payment_budget':
+                    if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
+                        $payment_budgets=payments__load_budgets();
+                        if (isset($payment_budgets[$p['payment_budget']])) $row[]=$payment_budgets[$p['payment_budget']]['budget_name']; else $row[]='-';
+                    }
+                    break;
+                case 'payment_type':
+                    if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
+                        $payment_types=payments__load_paytypes();
+                        if (isset($payment_types[$p['payment_type']])) $row[]=$payment_types[$p['payment_type']]; else $row[]='-';
+                    }
+                    break;
+                case 'payment_amount':
+                    if($settings['enable_payment_module']=='y' && check_allow('payments_view')) {
+                        if ($p['payment_amt']!='') $row[]=$p['payment_amt']; else $row[]='-';
+                    }
+                    break;
+                case 'pstatus_id':
+                    $pstatuses=expregister__get_participation_statuses();
+                    $row[]=$pstatuses[$p['pstatus_id']]['internal_name'];
+                    break;
+                default:
+                    if (isset($pform_columns[$k])) {
+                        if(preg_match("/(radioline|select_list|select_lang|radioline_lang)/",$pform_columns[$k]['type'])) {
+                            if (isset($pform_columns[$k]['lang'][$p[$k]])) $row[]=lang($pform_columns[$k]['lang'][$p[$k]]);
+                            else $row[]=$p[$k];
+                        } else $row[]=$p[$k];
+                    } else {
+                        if (isset($p[$k])) $row[]=$p[$k];
+                        else $row[]='???';
+                    }
+            }
         }
     }
     foreach ($row as $k=>$v) $row[$k]=str_replace("&nbsp;"," ",$v);

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -1293,49 +1293,49 @@ function participant__get_possible_participant_columns($listtype) {
 
     $cols=array();
     if ($listtype=='result_table_search_active' || $listtype=='result_table_search_all') {
-        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
-        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
     } elseif ($listtype=='result_table_assign') {
-        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
         $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='result_table_search_duplicates') {
         $cols['pform_fields']='';
         $cols['other_pfields']='';
-        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
     } elseif ($listtype=='result_table_search_unconfirmed') {
-        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
         $cols['email_unconfirmed']=array('display_text'=>lang('email_with_confirmation_email'),'on_list'=>true,'allow_remove'=>false,'sortable'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
-        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
     } elseif ($listtype=='experiment_assigned_list') {
-        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
+        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
         $cols['invited']=array('display_text'=>lang('invited'),'on_list'=>true,'allow_remove'=>false);
         $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='session_participants_list') {
-        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false);
-        $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false);
+        $cols['checkbox']=array('display_text'=>lang('checkbox'),'on_list'=>true,'allow_remove'=>false,'sortable'=>false,'disallow_hide'=>true);
+        $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false,'disallow_hide'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
         $cols['session_id']=array('display_text'=>lang('session'),'on_list'=>true,'allow_remove'=>false,'sort_order'=>'session_id');
         $cols['payment_budget']=array('display_text'=>lang('payment_budget'),'display_table_head'=>lang('payment_budget_abbr'),'on_list'=>true,'allow_remove'=>false);
         $cols['payment_type']=array('display_text'=>lang('payment_type'),'display_table_head'=>lang('payment_type_abbr'),'on_list'=>true,'allow_remove'=>false);
         $cols['payment_amount']=array('display_text'=>lang('payment_amount'),'display_table_head'=>lang('payment_amount_abbr'),'on_list'=>true,'allow_remove'=>false,'sort_order'=>'payment_amt');
-        $cols['pstatus_id']=array('display_text'=>lang('participation_status'),'on_list'=>true,'allow_remove'=>false);
+        $cols['pstatus_id']=array('display_text'=>lang('participation_status'),'on_list'=>true,'allow_remove'=>false,'disallow_hide'=>true);
         $cols['edit_link']=array('display_text'=>lang('edit_link'),'on_list'=>false,'allow_remove'=>true,'sortable'=>false);
     } elseif ($listtype=='session_participants_list_pdf') {
-        $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false);
+        $cols['order_number']=array('display_text'=>lang('order_number'),'display_table_head'=>'&nbsp;','sortable'=>false,'disallow_hide'=>true);
         $cols['pform_fields']='';
         $cols['other_pfields']='';
-        $cols['session_id']=array('display_text'=>lang('session'),'on_list'=>true,'allow_remove'=>false,'sort_order'=>'session_id');
+        $cols['session_id']=array('display_text'=>lang('session'),'on_list'=>true,'allow_remove'=>false,'sort_order'=>'session_id','disallow_hide'=>true);
         $cols['payment_amount']=array('display_text'=>lang('payment_amount'),'display_table_head'=>lang('payment_amount_abbr'),'sort_order'=>'payment_amt');
-        $cols['pstatus_id']=array('display_text'=>lang('participation_status'));
+        $cols['pstatus_id']=array('display_text'=>lang('participation_status'),'disallow_hide'=>true);
     } elseif ($listtype=='email_participant_guesses_list') {
         $cols['email']=array('display_text'=>lang('email'),'on_list'=>true,'allow_remove'=>false,'sortable'=>true);
         $cols['pform_fields']='';
@@ -1485,13 +1485,23 @@ function participant__get_result_table_headcells_pdf($columns) {
 }
 
 function participant__get_result_table_row($columns,$p) {
-    global $settings, $color;
+    global $settings, $color, $expadmindata;
     global $thislist_sessions, $thislist_avail_payment_budgets, $thislist_avail_payment_types;
 
     $pform_columns=participant__load_all_pform_fields();
 
     $out='';
     foreach ($columns as $k=>$arr) {
+        $hide_for_admin_types=array();
+        if(isset($arr['item_details']['hide_admin_types'])) {
+            $hide_for_admin_types=explode(",",$arr['item_details']['hide_admin_types']);
+        }
+        if (in_array($expadmindata['admin_type'],$hide_for_admin_types)) {
+            $out.='<td class="small">'.lang('hidden_data_symbol').'</td>';
+        } else {
+        // THE SWITCH CLAUSE BELOW NEEDS TO BE INDENTED. I WILL DO THIS LATER, 
+        // SINCE IT COMPLETELY SCREWS UP THE GIT DIFF AND MAKES IT LOOK AS IF 
+        // THERE WERE MANY CHANGES TO IT - AND THERE ARE NOT
         switch($k) {
             case 'email_unconfirmed':
                 $message="";
@@ -1646,19 +1656,31 @@ function participant__get_result_table_row($columns,$p) {
                     $out.='</td>';
                 }
         }
+        // END SWITCH
+        }
     }
     return $out;
 }
 
 
 function participant__get_result_table_row_pdf($columns,$p) {
-    global $settings, $color;
+    global $settings, $color, $expadmindata;
     global $thislist_sessions;
 
     $pform_columns=participant__load_all_pform_fields();
 
     $row=array();
     foreach ($columns as $k=>$arr) {
+        $hide_for_admin_types=array();
+        if(isset($arr['item_details']['hide_admin_types'])) {
+            $hide_for_admin_types=explode(",",$arr['item_details']['hide_admin_types']);
+        }
+        if (in_array($expadmindata['admin_type'],$hide_for_admin_types)) {
+            $row[]=lang('hidden_data_symbol');
+        } else {
+        // THE SWITCH CLAUSE BELOW NEEDS TO BE INDENTED. I WILL DO THIS LATER, 
+        // SINCE IT COMPLETELY SCREWS UP THE GIT DIFF AND MAKES IT LOOK AS IF 
+        // THERE WERE MANY CHANGES TO IT - AND THERE ARE NOT
         switch($k) {
             case 'number_noshowup':
                 $row[]=$p['number_noshowup'].'/'.$p['number_reg'];
@@ -1731,6 +1753,8 @@ function participant__get_result_table_row_pdf($columns,$p) {
                     if (isset($p[$k])) $row[]=$p[$k];
                     else $row[]='???';
                 }
+        }
+        // END SWITCH
         }
     }
     foreach ($row as $k=>$v) $row[$k]=str_replace("&nbsp;"," ",$v);


### PR DESCRIPTION
In the configuration of result lists, this allows to specify for each column whether the data in this column should be hidden (replaced by a symbol, e.g. ***) for sepcified admin usertypes. The respective admin typoes have to be added by name as a comma-separated list - syntax is checked before saving the entered list. (Due to interactions between different javascript codes, it was not possible to use the multipicker applet here.) When displaying any of the lists for which columns can be hidden, the code now checks whether the current administrator pertains the respective rights to see this data.