### PR TITLE
Feature: Allow restrict no-show calc to sessions after a particular date

### DIFF
--- a/admin/options_edit.php
+++ b/admin/options_edit.php
@@ -7,7 +7,7 @@ if (isset($_REQUEST['otype']) && $_REQUEST['otype']) {
     elseif ($_REQUEST['otype']=="default") $title='edit_default_values';
 }
 
-$jquery=array('switchy');
+$jquery=array('switchy','datepicker');
 $menu__area="options_main";
 include ("header.php");
 if ($proceed) {
@@ -21,6 +21,9 @@ if ($proceed) {
         $otype="";
         redirect ("admin/options_main.php");
     }
+
+    if ($otype=='general') $opts=$system__options_general;
+    else $opts=$system__options_defaults;
 
     echo '<center>';
 
@@ -36,6 +39,14 @@ if ($proceed) {
 
     if (check_allow('settings_edit') && isset($_REQUEST['change']) && $_REQUEST['change']) {
         $newoptions=$_REQUEST['options']; $now=time();
+        
+        // add and process option values which may be differently submitted
+        foreach ($opts as $o) {
+            if($o['type']=='date') {
+                $newoptions[$o['option_name']]=ortime__array_to_sesstime($_REQUEST,'options__'.$o['option_name'].'_');
+            }
+        }
+        
         $pars_new=array(); $pars_update=array();
         foreach ($newoptions as $oname => $ovalue) {
             if (isset($options[$oname])) {
@@ -84,9 +95,6 @@ if ($proceed) {
                 </TD>
             </TR>
             <TR><TD colspan=2><hr></TD></TR>';
-
-    if ($otype=='general') $opts=$system__options_general;
-    else $opts=$system__options_defaults;
 
     foreach ($opts as $o) {
         $done=options__show_option($o);

--- a/config/system.php
+++ b/config/system.php
@@ -628,7 +628,19 @@ $system__options_general[]=array(
 'default_value'=>'n'
 );
 
+$system__options_general[]=array(
+'option_name'=>'restrict_noshow_warnings_to_date',
+'option_text'=>'Restrict calculation of no-shows to sessions after a certain date?',
+'type'=>'select_yesno_switchy',
+'default_value'=>'n'
+);
 
+$system__options_general[]=array(
+'option_name'=>'restrict_noshow_warnings_date',
+'option_text'=>'If yes, use this date:',
+'type'=>'date',
+'default_value'=>'0'
+);
 
 $system__options_general[]=array('type'=>'line');
 

--- a/tagsets/cronjobs.php
+++ b/tagsets/cronjobs.php
@@ -260,6 +260,7 @@ function cron__participants_update_history_participant($part,$what) {
 }
 
 function cron__update_participants_history() {
+    global $settings;
     $logm="";
 
     // initialize with zero
@@ -285,6 +286,12 @@ function cron__update_participants_history() {
     $logm.="updated participant's number_reg: ".$n."\n";
 
     $noshow_clause=expregister__get_pstatus_query_snippet("noshow");
+    
+    $restrict_date_clause="";
+    if ($settings['restrict_noshow_warnings_to_date']=='y' && $settings['restrict_noshow_warnings_date']>0) {
+        $restrict_date_clause=" AND ".table('sessions').".session_start > ".$settings['restrict_noshow_warnings_date']." ";
+    } 
+    
     $query="SELECT ".table('participate_at').".participant_id,
             count(*) as number_noshowup
             FROM ".table('participate_at').", ".table('sessions').", ".table('experiments')."
@@ -292,6 +299,7 @@ function cron__update_participants_history() {
             AND ".table('participate_at').".experiment_id = ".table('experiments').".experiment_id
             AND hide_in_stats = 'n'
             AND (session_status='completed' OR session_status='balanced')
+            ".$restrict_date_clause." 
             AND ".table('participate_at').".session_id != 0
             AND ".$noshow_clause."
             GROUP BY participant_id";

--- a/tagsets/survey.php
+++ b/tagsets/survey.php
@@ -11,6 +11,7 @@ function survey__render_field($field) {
         case 'select_numbers': $out=survey__render_select_numbers($field); break;
         case 'select_yesno': $out=survey__render_select_yesno($field); break;
         case 'select_yesno_switchy': $out=survey__render_select_yesno_switchy($field); break;
+        case 'date': $out=survey__render_date($field); break;
     }
     return $out;
 }
@@ -120,5 +121,15 @@ function survey__render_select_yesno_switchy($f) {
     return $out;
 }
 
+function survey__render_date($f,$formfieldvarname='') {
+    global $lang;
+    if (!$formfieldvarname) $formfieldvarname=$f['submitvarname'];
+    if (preg_match('/([^\[]+)\[([^\[\]]+)\]/', $formfieldvarname, $matches)) {
+        $formfieldvarname=$matches[1]."__".$matches[2];
+    }
+    $out='';
+    $out=formhelpers__pick_date($formfieldvarname,$f['value']);
+    return $out;
+}
 
 ?>


### PR DESCRIPTION
Upon user request, this feature allows to restrict the count of no-shows to experiment sessions which took place after a particular date. To do this, we added two new options to General Settings: Enable restriction or not, and set the respective date from which on no-shows will be counted. The cronjob that calculates and updates participants' history was amended such that it if the restriction is enabled and a date has been set, it only considers sessions after that date when calculating the number of no-shows.

(On the way, we had to add a new option type "date" to the collection of possible option types. We also had to add a fix to the datepicker since an array variable as a form element name would break the date field code. Future code that uses the datepicker can now use an array element as the name for the form field, but will have to piece the submitted values together afterwards (see changes to top of admin/options_edit.php).)