### PR TITLE
Bugfix: Redirect to login when accessing profile page without auth

### DIFF
--- a/public/header.php
+++ b/public/header.php
@@ -117,13 +117,14 @@ if ($proceed) {
                             redirect("public/participant_reset_pw.php");
                     }
                 } else {
-                // and if we only allow username/passsword, send to login page
+                // send to login page if no token is present
                     if (isset($mobile) && $mobile) redirect("public/participant_login_mob.php");
                     else redirect("public/participant_login.php");
                 }
             } else {
-
-
+                // and if we only allow username/passsword, send to login page
+                if (isset($mobile) && $mobile) redirect("public/participant_login_mob.php");
+                else redirect("public/participant_login.php");
             }
         }
         if ($proceed) {


### PR DESCRIPTION
This bugfix addresses an issue where participants who access their
participant profile / enroilment page without being logged in are not
redirected to the login page but are displayed an empty page instead.
There was a proper redirect missing in the code, which is added in this
fix.