### PR TITLE
Feature: Payment details in participant history

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -449,7 +449,12 @@ $system__options_general[]=array(
 'default_value'=>'n'
 );
 
-
+$system__options_general[]=array(
+'option_name'=>'payments_in_part_history',
+'option_text'=>'If payment module enabled: Include payments in participant\'s history?',
+'type'=>'select_yesno_switchy',
+'default_value'=>'n'
+);
 
 $system__options_general[]=array(
 'option_name'=>'enable_rules_signed_tracking',

--- a/public/participant_show_mob.php
+++ b/public/participant_show_mob.php
@@ -366,6 +366,7 @@ if ($proceed) {
         if (count($history)>0) echo '<ul data-role="listview" data-theme="a" data-inset="true">';
 
         $pstatuses=expregister__get_participation_statuses();
+        $payment_types=payments__load_paytypes();
         foreach ($history as $s) {
             echo '<li><strong>'.$s['session_name'].'</strong><br>
             '.lang('experiment').': '.$s['experiment_public_name'].'<br>
@@ -382,6 +383,20 @@ if ($proceed) {
                 $ttext=$pstatuses[$s['pstatus_id']]['display_name'];
                 echo '<FONT color="'.$tcolor.'"><strong>'.$ttext.'</strong></FONT>';
             } else echo '<FONT color="grey"><strong>'.lang('three_questionmarks').'</strong></FONT>';
+            if ($settings['enable_payment_module']=='y' && $settings['payments_in_part_history']=='y') {
+                echo '<br>'.lang('payment_type_abbr').': ';
+                if (isset($payment_types[$s['payment_type']])) {
+                    echo $payment_types[$s['payment_type']]; 
+                } else {
+                    echo '-';
+                }
+                echo ', '.lang('payment_amount_abbr').': ';
+                if ($s['payment_amt']!='') {
+                    echo $s['payment_amt'];
+                } else {
+                    echo '-';
+                }
+            }
             echo '</li>';
         }
         if (count($history)>0) echo '</ul>';

--- a/tagsets/expregister.php
+++ b/tagsets/expregister.php
@@ -215,11 +215,15 @@ function expregister__get_history($participant_id) {
 }
 
 function expregister__list_history($participant) {
-    global $lang, $color, $preloaded_laboratories;
+    global $settings, $lang, $color, $preloaded_laboratories, $preloaded_payment_types;
 
     if (!(is_array($preloaded_laboratories) && count($preloaded_laboratories)>0))
         $preloaded_laboratories=laboratories__get_laboratories();
-
+        
+    if (!(is_array($preloaded_payment_types) && count($preloaded_payment_types)>0)) {
+        $preloaded_payment_types=payments__load_paytypes();
+    }
+    
     $history=expregister__get_history($participant['participant_id']);
 
     echo '<TABLE width=100% border=0 cellspacing="0">';
@@ -229,8 +233,14 @@ function expregister__list_history($participant) {
                 <TD>'.lang('experiment').'</TD>
                 <TD>'.lang('date_and_time').'</TD>
                 <TD>'.lang('location').'</TD>
-                <TD>'.lang('showup?').'</TD>
-                </TR>';
+                <TD>'.lang('showup?').'</TD>';
+        if ($settings['enable_payment_module']=='y' && $settings['payments_in_part_history']=='y') {
+            echo '
+                <TD>'.lang('payment_type_abbr').'</TD>
+                <TD>'.lang('payment_amount_abbr').'</TD>
+                ';
+        }
+        echo '</TR>';
     } else echo '<TD>'.lang('mobile_no_past_enrolments').'</TD>';
 
     $labs=array(); $shade=true;
@@ -258,6 +268,21 @@ function expregister__list_history($participant) {
             echo '<FONT color="'.$tcolor.'">'.$ttext.'</FONT>';
         } else echo lang('three_questionmarks');
         echo '</TD>';
+        if ($settings['enable_payment_module']=='y' && $settings['payments_in_part_history']=='y') {
+            echo '<TD>';
+            if (isset($preloaded_payment_types[$s['payment_type']])) {
+                echo $preloaded_payment_types[$s['payment_type']]; 
+            } else {
+                echo '-';
+            }
+            echo '</TD><TD>';
+            if ($s['payment_amt']!='') {
+                echo $s['payment_amt'];
+            } else {
+                echo '-';
+            }
+            echo '</TD>';
+        }
         echo '</TR>';
         $labs[$s['laboratory_id']]=$s['laboratory_id'];
     }

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -68,7 +68,7 @@ function participants__get_statistics($participant_id) {
 }
 
 function participants__stat_laboratory($participant_id) {
-    global $lang, $color;
+    global $settings, $lang, $color;
 
     $exptypes=load_external_experiment_types();
 
@@ -98,12 +98,20 @@ function participants__stat_laboratory($participant_id) {
     echo '<TD>'.lang('date_and_time').'</TD>
         <TD>'.lang('registered').'</TD>
         <TD>'.lang('location').'</TD>
-        <TD>'.lang('participation_status').'</TD>
+        <TD>'.lang('participation_status').'</TD>';
+    if ($settings['enable_payment_module']=='y' && (check_allow('payments_view') || check_allow('payments_edit'))) {
+        echo '
+                <TD>'.lang('payment_type_abbr').'</TD>
+                <TD>'.lang('payment_amount_abbr').'</TD>
+            ';
+    }
+    echo '
         </TR></thead>
         <tbody>';
 
     $pstatuses=expregister__get_participation_statuses();
     $laboratories=laboratories__get_laboratories();
+    $payment_types=payments__load_paytypes();
     while ($p=pdo_fetch_assoc($result)) {
         $last_reg_time=0;
         //if ($p['sess_id']=='0') $last_reg_time=sessions__get_registration_end("","",$p['exp_id']);
@@ -151,8 +159,23 @@ function participants__stat_laboratory($participant_id) {
             if ($p['pstatus_id']>0) {
                 echo '</FONT>';
             }
-            echo '  </TD>
-                  </TR>';
+            echo '  </TD>';
+            if ($settings['enable_payment_module']=='y' && (check_allow('payments_view') || check_allow('payments_edit'))) {
+                echo '<TD>';
+                if (isset($payment_types[$p['payment_type']])) {
+                    echo $payment_types[$p['payment_type']]; 
+                } else {
+                    echo '-';
+                }
+                echo '</TD><TD>';
+                if ($p['payment_amt']!='') {
+                    echo $p['payment_amt'];
+                } else {
+                    echo '-';
+                }
+                echo '</TD>';
+            }
+            echo '</TR>';
             if ($shade) $shade=false; else $shade=true;
         }
     }


### PR DESCRIPTION
This adds payment details to the participant history displayed to admins
on the participant profile page (if the payment module is enabled and
the respective user has the rights "payments_view" or payments_edit").
Addtionally, there is a new setting "If payment module enabled: Include
payments in participant's history?" in "General Settings". If enabled,
then also the participant will see payment details in her history (both
on desktop and mobile ORSEE page).