### PR TITLE
Bugfix: Bulk mailing stops when participant uses previously existing …

### DIFF
--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -111,7 +111,7 @@ function experimentmail__load_bulk_mail($bulk_id,$tlang="") {
         $query="SELECT * from ".table('bulk_mail_texts')."
                 WHERE bulk_id= :bulk_id
                 AND lang= :tlang";
-        $bulk_mail=orsee_query($query);
+        $bulk_mail=orsee_query($query,$pars);
     }
     return $bulk_mail;
 }


### PR DESCRIPTION
…language

A bulk mailing may stop in rare cases when a participant uses a language that has been deleted from the ORSEE system. Reason is a bug where parameters where not included in an SQL query call. This fixes that.