### PR TITLE
Bugfix: "Add conditon" list empty in query builder

### DIFF
--- a/tagsets/helpers.php
+++ b/tagsets/helpers.php
@@ -347,4 +347,18 @@ function or_array_delete_values($array,$values) {
     return $array;
 }
 
+function fix_utf8($mixed) {
+    if (is_array($mixed)) {
+        foreach ($mixed as $key => $value) {
+            $mixed[$key] = fix_utf8($value);
+	}
+	return $mixed;
+    } elseif (is_string($mixed)) {
+        return mb_convert_encoding($mixed,'UTF-8','UTF-8');
+    } else { 
+    	return $mixed;
+    }    
+}
+
+
 ?>

--- a/tagsets/query.php
+++ b/tagsets/query.php
@@ -147,11 +147,11 @@ function query__echo_form_javascript($prototypes,$load_query="") {
             );
         }
         echo "<script type='text/javascript'>var Ptypes = ";
-        echo json_encode($tmp);
+        echo json_encode(fix_utf8($tmp));
         echo ";
             buildDropdown();
             ";
-        echo "</script>";
+	echo "</script>";
 
 }
 


### PR DESCRIPTION
In some ORSEE installations, the "Add conditon" dropdown list is empty, and queries cannot be built. This happens when upgrading from version 3.0.5 to version 3.1.0. It is hypothesized that this is due to using
  PHP's json_encoding() function in the newer ORSEE version, and that
this function may not be able to handle some malformed UTF8 characters. This fix tries to sanitize the output before piping it into json_encode.