### PR TITLE
New Feature: Custom inv email template for exp types

### DIFF
--- a/admin/experiment_mail_participants.php
+++ b/admin/experiment_mail_participants.php
@@ -123,7 +123,10 @@ if ($proceed) {
         }
 
         if (!$body) {
-            $body=load_mail('default_invitation_'.$experiment['experiment_type'],$inv_lang);
+            $body=load_mail('default_invitation_'.$experiment['experiment_type'].'_'.$experiment['experiment_ext_type'],$inv_lang);
+            if (!$body) {
+                $body=load_mail('default_invitation_'.$experiment['experiment_type'],$inv_lang);
+            }
         }
 
         if (count($inv_langs) > 1) {

--- a/config/system.php
+++ b/config/system.php
@@ -118,7 +118,7 @@ $system__admin_rights=array(
 "log_file_regular_tasks_delete:delete log file of regular system tasks:log_file_regular_tasks_show",
 "log_file_regular_tasks_show:view log file of regular tasks",
 "login:login into administration area",
-"mail_add:add new default email text - dev!:mail_edit",
+"mail_add:add new default email text:mail_edit",
 "mail_delete:delete default email text - dev!:mail_edit",
 "mail_edit:edit default email texts",
 "mailqueue_edit_all:delete emails from overall mail queue:mailqueue_show_all",


### PR DESCRIPTION
Previously, different invitation email templates existed for different "internal" experiment types: laboratory, online-survey, internet. This fix now allows to also create email templates customized to external, user-defined experiment types (e.g. "eye-tracking expeirments").

Technically, when loading the default for the invitation email for an experiment, ORSEE will first look for an email template "default_invitation_laboratory_4", with 4 being the id of the user-defined "external experiment type". If this is not found, then it will load the standard template "default_invitation_laboratory".