### PR TITLE
Bugfix: Returning bool from uasort() deprecated, now returning integer

### DIFF
--- a/tagsets/helpers.php
+++ b/tagsets/helpers.php
@@ -24,12 +24,32 @@ function multi_array_sort(&$data, $sortby) {
         $sorting_var1 = $sortby;
     } 
     uasort($data,function ($a,$b) use ($sorting_var1, $sorting_var2, $sorting_var3) {
-        if ($a[$sorting_var1]!=$b[$sorting_var1] || (!$sorting_var2)) {
-            return $a[$sorting_var1]>$b[$sorting_var1];
-        } elseif ($a[$sorting_var2]!=$b[$sorting_var2] || (!$sorting_var3)) {
-            return $a[$sorting_var2]>$b[$sorting_var2];
+        if ($a[$sorting_var1]>$b[$sorting_var1]) {
+            return 1;
+        } elseif ($a[$sorting_var1]<$b[$sorting_var1]) {
+            return -1;
         } else {
-            return $a[$sorting_var3]>$b[$sorting_var3];
+            if (!$sorting_var2) {
+                return 0;
+            } else {
+                if ($a[$sorting_var2]>$b[$sorting_var2]) {
+                    return 1;
+                } elseif ($a[$sorting_var2]<$b[$sorting_var2]) {
+                    return -1;
+                } else {
+                    if (!$sorting_var3) {
+                        return 0;
+                    } else {
+                        if ($a[$sorting_var3]>$b[$sorting_var3]) {
+                            return 1;
+                        } elseif ($a[$sorting_var3]<$b[$sorting_var3]) {
+                            return -1;
+                        } else {
+                            return 0;
+                        }
+                    }
+                }
+            }
         }
     });
 }


### PR DESCRIPTION
In the function multi_array_sort() in helpers.php, we use php function uasort() to implement the sorting over several array keys. The function now requires an integer (smaller 0, equal 0, or larger 0) to be returned, while previously we returned a boolean.
One could use the spaceship operator "<=>" for that, but this operator was only introduced in PHP7, so to maintain backward compatibility, we do the comparision manually using "<", ">".

Hat tip to PhDH-UKS's (https://github.com/PhDH-UKS) comment on https://github.com/orsee/orsee/commit/1ae6b7a767d37179cb10e4560c7fc860272ab932#commitcomment-133477706
