### PR TITLE
Bugfix: Language cannot be deleted

### DIFF
--- a/admin/lang_lang_delete.php
+++ b/admin/lang_lang_delete.php
@@ -54,7 +54,7 @@ if ($proceed) {
             foreach ($tables as $table) {
                 $pars=array(':slang'=>$slang,':tlang'=>$tlang);
                 $query="UPDATE ".table($table)." SET language= :slang WHERE language= :tlang";
-                $done=or_query($query,pars);
+                $done=or_query($query,$pars);
             }
             message(lang('updated_language_settings'));
 


### PR DESCRIPTION
Due to a missing $ in front of variable $pars for the database command, a language cannot be deleted. This fix adds the $.