### PR TITLE
Bugfixes: fixing php8 compatibility issues

### DIFF
--- a/admin/header.php
+++ b/admin/header.php
@@ -19,12 +19,7 @@ if ($proceed) {
     $settings['style']=$settings['orsee_admin_style'];
     $color=load_colors();
 
-    session_set_save_handler("orsee_session_open",
-                 "orsee_session_close",
-                 "orsee_session_read",
-                 "orsee_session_write",
-                 "orsee_session_destroy",
-                 "orsee_session_gc");
+    orsee_session_register_handler();
 
     session_start();
 

--- a/admin/header.php
+++ b/admin/header.php
@@ -26,7 +26,9 @@ if ($proceed) {
     if (isset($_SESSION['expadmindata'])) $expadmindata=$_SESSION['expadmindata']; else $expadmindata=array();
 
     $tmparr=explode("/",$_SERVER['PHP_SELF']); $tmpnum=count($tmparr);
-    $requested_url=$tmparr[$tmpnum-2]."/".$tmparr[$tmpnum-1].'?'.$_SERVER['QUERY_STRING'];
+    if (isset($_SERVER['QUERY_STRING']) && $_SERVER['QUERY_STRING']) $query_string='?'.$_SERVER['QUERY_STRING'];
+    else $query_string='';
+    $requested_url=$tmparr[$tmpnum-2]."/".$tmparr[$tmpnum-1].$query_string;
 
     // Check for login
     if ((!(isset($expadmindata['adminname']) && $expadmindata['adminname'])) && $document!="admin_login.php") {

--- a/admin/nonoutputheader.php
+++ b/admin/nonoutputheader.php
@@ -17,7 +17,7 @@ if ($proceed) {
     $settings=load_settings();
     $settings['style']=$settings['orsee_admin_style'];
     $color=load_colors();
-    session_set_save_handler("orsee_session_open", "orsee_session_close", "orsee_session_read", "orsee_session_write", "orsee_session_destroy", "orsee_session_gc");
+    orsee_session_register_handler();
     session_start();
     if (isset($_SESSION['expadmindata'])) $expadmindata=$_SESSION['expadmindata']; else $expadmindata=array();
 

--- a/install/data_import.php
+++ b/install/data_import.php
@@ -146,7 +146,7 @@ function detectUTF8($string) {
 function convert_array_to_UTF8($arr) {
     foreach($arr as $k=>$v) {
         if (!detectUTF8(stripslashes($v))) {
-            $arr[$k]=utf8_encode(stripslashes($v));
+            $arr[$k]=mb_convert_encoding(stripslashes($v), 'UTF-8', 'ISO-8859-1');
         }
     }
     return $arr;

--- a/install/data_import_txt.php
+++ b/install/data_import_txt.php
@@ -70,7 +70,7 @@ function detectUTF8($string) {
 function convert_array_to_UTF8($arr) {
     foreach($arr as $k=>$v) {
         if (!detectUTF8(stripslashes($v))) {
-            $arr[$k]=utf8_encode(stripslashes($v));
+            $arr[$k]=mb_convert_encoding(stripslashes($v), 'UTF-8', 'ISO-8859-1');
         }
     }
     return $arr;

--- a/install/data_update_txt.php
+++ b/install/data_update_txt.php
@@ -63,7 +63,7 @@ function detectUTF8($string) {
 function convert_array_to_UTF8($arr) {
     foreach($arr as $k=>$v) {
         if (!detectUTF8(stripslashes($v))) {
-            $arr[$k]=utf8_encode(stripslashes($v));
+            $arr[$k]=mb_convert_encoding(stripslashes($v), 'UTF-8', 'ISO-8859-1');
         }
     }
     return $arr;

--- a/public/captcha.php
+++ b/public/captcha.php
@@ -35,5 +35,4 @@ header('Content-type: image/png');
 header('Pragma: no-cache');
 header('Cache-Control: no-store, no-cache, proxy-revalidate');
 imagepng($im);
-imagedestroy($im);
 ?>

--- a/public/header.php
+++ b/public/header.php
@@ -12,7 +12,7 @@ if ($proceed) {
     $settings=load_settings();
     $settings['style']=$settings['orsee_public_style'];
     $color=load_colors();
-    session_set_save_handler("orsee_session_open", "orsee_session_close", "orsee_session_read", "orsee_session_write", "orsee_session_destroy", "orsee_session_gc");
+    orsee_session_register_handler();
     session_start();
     $_REQUEST=strip_tags_array($_REQUEST);
 }

--- a/tagsets/class.fmailbox.php
+++ b/tagsets/class.fmailbox.php
@@ -1197,7 +1197,7 @@ class fMailbox
      */
     public function enableDebugging($flag)
     {
-        $this->debug = (boolean) $flag;
+        $this->debug = (bool) $flag;
     }
 
 

--- a/tagsets/class.fmailbox.php
+++ b/tagsets/class.fmailbox.php
@@ -253,7 +253,7 @@ class fMailbox
         foreach ($part_with_encoding as $part) {
             if (!fmailbox_detectUTF8($part['string'])) {
                 //$output .= self::iconv($part['encoding'], 'UTF-8', $part['string']);
-                $output .= utf8_encode($part['string']);
+                $output .= mb_convert_encoding($part['string'], 'UTF-8', 'ISO-8859-1');
             }
         }
 
@@ -329,7 +329,7 @@ class fMailbox
                 }
             }
             //$content = self::iconv($charset, 'UTF-8', $content);
-            $content = utf8_encode($content);
+            $content = mb_convert_encoding($content, 'UTF-8', 'ISO-8859-1');
             if ($structure['subtype'] == 'html') {
                 $content = preg_replace('#(content=(["\'])text/html\s*;\s*charset=(["\']?))' . preg_quote($charset, '#') . '(\3\2)#i', '\1utf-8\4', $content);
             }

--- a/tagsets/class.pdf.php
+++ b/tagsets/class.pdf.php
@@ -2993,7 +2993,7 @@ class Cpdf
         }
 
         if (mb_detect_encoding($text) != 'UTF-8') {
-            $text = utf8_encode($text);
+            $text = mb_convert_encoding($text, 'UTF-8', 'ISO-8859-1');
         }
 
         $orgWidth = $width;

--- a/tagsets/class.pdf.php
+++ b/tagsets/class.pdf.php
@@ -3519,7 +3519,6 @@ class Cpdf
                         $tmpfile_alpha = tempnam($this->tempPath, 'ezImg');
 
                         imagepng($imgalpha, $tmpfile_alpha);
-                        imagedestroy($imgalpha);
 
                         $alphaData = file_get_contents($tmpfile_alpha);
                         // nested method call to receive info on alpha image
@@ -3533,7 +3532,6 @@ class Cpdf
                         $imgplain = imagecreatetruecolor($default['info']['width'], $default['info']['height']);
                         imagecopy($imgplain, $img, 0, 0, 0, 0, $default['info']['width'], $default['info']['height']);
                         imagepng($imgplain, $tmpfile_tt);
-                        imagedestroy($imgplain);
 
                         $ttData = file_get_contents($tmpfile_tt);
                         $ttImg = $this->readPngChunks($ttData);

--- a/tagsets/class.phplot.php
+++ b/tagsets/class.phplot.php
@@ -1859,7 +1859,7 @@ class PHPlot
             $y = $ypos - $r10 * $factor;
 
             // Call ImageString or ImageStringUp:
-            $draw_func($this->img, $font_number, $x, $y, $lines[$i], $color);
+            $draw_func($this->img, (int)$font_number, (int)$x, (int)$y, $lines[$i], (int)$color);
 
             // Step to the next line of text. This is a rotation of (x=0, y=interline_spacing)
             $xpos += $r01 * $interline_step;
@@ -2193,7 +2193,7 @@ class PHPlot
     {
         $this->bgmode = $this->CheckOption($mode, 'tile, centeredtile, scale', __FUNCTION__);
         $this->bgimg  = $input_file;
-        return (boolean)$this->bgmode;
+        return (bool)$this->bgmode;
     }
 
     /**
@@ -2207,7 +2207,7 @@ class PHPlot
     {
         $this->plotbgmode = $this->CheckOption($mode, 'tile, centeredtile, scale', __FUNCTION__);
         $this->plotbgimg  = $input_file;
-        return (boolean)$this->plotbgmode;
+        return (bool)$this->plotbgmode;
     }
 
     /**
@@ -2646,7 +2646,7 @@ class PHPlot
             $type = '';
         }
         $format['type'] = $type;
-        return (boolean)$type;
+        return (bool)$type;
     }
 
     /**
@@ -3034,7 +3034,7 @@ class PHPlot
     function SetImageBorderType($sibt)
     {
         $this->image_border_type = $this->CheckOption($sibt, 'raised, plain, solid, none', __FUNCTION__);
-        return (boolean)$this->image_border_type;
+        return (bool)$this->image_border_type;
     }
 
     /**
@@ -3234,7 +3234,7 @@ class PHPlot
     {
         $avail_plot_types = implode(', ', array_keys(self::$plots)); // List of known plot types
         $this->plot_type = $this->CheckOption($which_pt, $avail_plot_types, __FUNCTION__);
-        return (boolean)$this->plot_type;
+        return (bool)$this->plot_type;
     }
 
     /**
@@ -3300,7 +3300,7 @@ class PHPlot
     function SetXScaleType($which_xst)
     {
         $this->xscale_type = $this->CheckOption($which_xst, 'linear, log', __FUNCTION__);
-        return (boolean)$this->xscale_type;
+        return (bool)$this->xscale_type;
     }
 
     /**
@@ -3312,7 +3312,7 @@ class PHPlot
     function SetYScaleType($which_yst)
     {
         $this->yscale_type = $this->CheckOption($which_yst, 'linear, log',  __FUNCTION__);
-        return (boolean)$this->yscale_type;
+        return (bool)$this->yscale_type;
     }
 
     /**
@@ -3386,7 +3386,7 @@ class PHPlot
     function SetErrorBarShape($which_ebs)
     {
         $this->error_bar_shape = $this->CheckOption($which_ebs, 'tee, line', __FUNCTION__);
-        return (boolean)$this->error_bar_shape;
+        return (bool)$this->error_bar_shape;
     }
 
     /**
@@ -3479,7 +3479,7 @@ class PHPlot
         // Validate the datatype argument against the available data types:
         $valid_data_types = implode(', ', array_keys(self::$datatypes));
         $this->data_type = $this->CheckOption($which_dt, $valid_data_types, __FUNCTION__);
-        return (boolean)$this->data_type;
+        return (bool)$this->data_type;
     }
 
     /**
@@ -3955,7 +3955,7 @@ class PHPlot
             $j = 1; // Skips label at [0]
 
             if (!$this->datatype_implied) {
-                $all_iv[] = (double)$this->data[$i][$j++];
+                $all_iv[] = (float)$this->data[$i][$j++];
             }
 
             if ($sum_vals) {
@@ -3967,8 +3967,8 @@ class PHPlot
                 if (is_numeric($val = $this->data[$i][$j++])) {
 
                     if ($this->datatype_error_bars) {
-                        $all_dv[] = $val + (double)$this->data[$i][$j++];
-                        $all_dv[] = $val - (double)$this->data[$i][$j++];
+                        $all_dv[] = $val + (float)$this->data[$i][$j++];
+                        $all_dv[] = $val - (float)$this->data[$i][$j++];
                     } else {
                         if ($abs_vals) {
                             $val = abs($val); // Use absolute values
@@ -5053,7 +5053,7 @@ class PHPlot
         } else {
             $x_pixels = $this->plot_origin_x + $x_world * $this->xscale ;
         }
-        return round($x_pixels);
+        return (int)round($x_pixels);
     }
 
     /**
@@ -5071,7 +5071,7 @@ class PHPlot
         } else {
             $y_pixels =  $this->plot_origin_y - $y_world * $this->yscale ;
         }
-        return round($y_pixels);
+        return (int)round($y_pixels);
     }
 
     /**
@@ -5130,8 +5130,8 @@ class PHPlot
         }
 
         // To avoid losing a final tick mark due to round-off errors, push tick_end out slightly.
-        $tick_start = (double)$plot_min;
-        $tick_end = (double)$plot_max + ($plot_max - $plot_min) / 10000.0;
+        $tick_start = (float)$plot_min;
+        $tick_end = (float)$plot_max + ($plot_max - $plot_min) / 10000.0;
 
         // If a tick anchor was given, adjust the start of the range so the anchor falls
         // at an exact tick mark (or would, if it was within range).
@@ -5480,7 +5480,7 @@ class PHPlot
     protected function TuneAutoTicks($which, $min_ticks, $tick_mode, $tick_inc_integer)
     {
         if (isset($min_ticks) && $min_ticks > 0)
-            $this->tickctl[$which]['min_ticks'] = (integer)$min_ticks;
+            $this->tickctl[$which]['min_ticks'] = (int)$min_ticks;
         if (isset($tick_mode)) {
             $tick_mode = $this->CheckOption($tick_mode, 'decimal, binary, date',
                                             'Tune' . strtoupper($which) . 'AutoTicks');
@@ -5588,7 +5588,7 @@ class PHPlot
     {
         $this->x_tick_pos = $this->CheckOption($which_tp, 'plotdown, plotup, both, xaxis, none',
                                                __FUNCTION__);
-        return (boolean)$this->x_tick_pos;
+        return (bool)$this->x_tick_pos;
     }
 
     /**
@@ -5601,7 +5601,7 @@ class PHPlot
     {
         $this->y_tick_pos = $this->CheckOption($which_tp, 'plotleft, plotright, both, yaxis, none',
                                               __FUNCTION__);
-        return (boolean)$this->y_tick_pos;
+        return (bool)$this->y_tick_pos;
     }
 
     /**
@@ -6620,7 +6620,7 @@ class PHPlot
     {
         $this->legend_colorbox_borders = $this->CheckOption($cbbmode, 'none, textcolor, databordercolor',
                                                             __FUNCTION__);
-        return (boolean)$this->legend_colorbox_borders;
+        return (bool)$this->legend_colorbox_borders;
     }
 
     /**
@@ -6795,11 +6795,11 @@ class PHPlot
         $box_end_x = $box_start_x + $width;
 
         // Draw outer box
-        ImageFilledRectangle($this->img, $box_start_x, $box_start_y, $box_end_x, $box_end_y,
-                             $this->ndx_legend_bg_color);
+        ImageFilledRectangle($this->img, (int)$box_start_x, (int)$box_start_y, (int)$box_end_x, (int)$box_end_y,
+                             (int)$this->ndx_legend_bg_color);
         if ($this->draw_legend_border) {
-           ImageRectangle($this->img, $box_start_x, $box_start_y, $box_end_x, $box_end_y,
-                          $this->ndx_legend_border_color);
+           ImageRectangle($this->img, (int)$box_start_x, (int)$box_start_y, (int)$box_end_x, (int)$box_end_y,
+                          (int)$this->ndx_legend_border_color);
         }
 
         // Calculate color box and text horizontal positions.
@@ -6859,8 +6859,8 @@ class PHPlot
 
                 // If plot area background is on, draw a background for any non-box shapes:
                 if ($this->draw_plot_area_background && $colorbox_mode != 'box') {
-                    ImageFilledRectangle($this->img, $dot_left_x, $y1, $dot_right_x, $y2,
-                                         $this->ndx_plot_bg_color);
+                    ImageFilledRectangle($this->img, (int)$dot_left_x, (int)$y1, (int)$dot_right_x, (int)$y2,
+                                         (int)$this->ndx_plot_bg_color);
                 }
 
                 switch ($colorbox_mode) {
@@ -6874,22 +6874,22 @@ class PHPlot
                     imagesetthickness($this->img, $this->line_widths[$lws_index]);
                     $style = $this->SetDashedStyle($this->ndx_data_colors[$color_index],
                                                    $this->line_styles[$lws_index] == 'dashed');
-                    imageline($this->img, $dot_left_x, $yc, $dot_right_x, $yc, $style);
+                    imageline($this->img, (int)$dot_left_x, (int)$yc, (int)$dot_right_x, (int)$yc, (int)$style);
                     imagesetthickness($this->img, 1);
                     if (++$lws_index >= $this->data_columns) $lws_index = 0; // Wrap around
                     break;
 
                 default:
                     // Draw color boxes:
-                    ImageFilledRectangle($this->img, $dot_left_x, $y1, $dot_right_x, $y2,
-                                         $this->ndx_data_colors[$color_index]);
+                    ImageFilledRectangle($this->img, (int)$dot_left_x, (int)$y1, (int)$dot_right_x, (int)$y2,
+                                         (int)$this->ndx_data_colors[$color_index]);
                    // Draw a rectangle around the box, if enabled.
                    if ($this->legend_colorbox_borders != 'none') {
                        if ($this->legend_colorbox_borders == 'databordercolor')
                            $color = $this->ndx_data_border_colors[$color_index];
                        else
                            $color = $this->ndx_text_color;
-                       ImageRectangle($this->img, $dot_left_x, $y1, $dot_right_x, $y2, $color);
+                       ImageRectangle($this->img, (int)$dot_left_x, (int)$y1, (int)$dot_right_x, (int)$y2, (int)$color);
                    }
                 }
                 if (++$color_index > $max_color_index) $color_index = 0;
@@ -7048,8 +7048,11 @@ class PHPlot
      */
     protected function DrawShape($x, $y, $record, $color, $allow_none = TRUE)
     {
+        $x = (int)$x;
+        $y = (int)$y;
+        $color = (int)$color;
         $index = $record % $this->point_counts;
-        $point_size = $this->point_sizes[$index];
+        $point_size = (int)$this->point_sizes[$index];
         $half_point = (int)($point_size / 2);
 
         $x1 = $x - $half_point;
@@ -7191,6 +7194,10 @@ class PHPlot
         if ($y1 > $y2) {
             $t = $y1; $y1 = $y2; $y2 = $t;
         }
+        $x1 = (int)$x1;
+        $y1 = (int)$y1;
+        $x2 = (int)$x2;
+        $y2 = (int)$y2;
 
         // Draw the bar
         ImageFilledRectangle($this->img, (int)$x1, (int)$y1, (int)$x2, (int)$y2, (int)$data_color);
@@ -7206,16 +7213,16 @@ class PHPlot
             } else { // Suppress top shading (Note shade_top==FALSE && shade_side==FALSE is not allowed)
                 $pts = array($x2, $y2, $x2, $y1, $x2 + $shade, $y1 - $shade, $x2 + $shade, $y2 - $shade);
             }
-            ImageFilledPolygon($this->img, $pts, count($pts) / 2, $shade_color);
+            ImageFilledPolygon($this->img, array_map('intval', $pts), (int)(count($pts) / 2), (int)$shade_color);
         }
 
         // Draw a border around the bar, if enabled.
         if (isset($border_color)) {
             // Avoid a PHP/GD bug with zero-height ImageRectangle resulting in "T"-shaped ends.
             if ($y1 == $y2)
-                imageline($this->img, $x1, $y1, $x2, $y2, $border_color);
+                imageline($this->img, (int)$x1, (int)$y1, (int)$x2, (int)$y2, (int)$border_color);
             else
-                imagerectangle($this->img, $x1, $y1, $x2, $y2, $border_color);
+                imagerectangle($this->img, (int)$x1, (int)$y1, (int)$x2, (int)$y2, (int)$border_color);
         }
         $this->DoCallback('data_points', 'rect', $row, $column, $x1, $y1, $x2, $y2);
         return TRUE;
@@ -7240,11 +7247,11 @@ class PHPlot
         $x2m = $this->xtr($x - $error_minus);
 
         imagesetthickness($this->img, $this->error_bar_line_width);
-        imageline($this->img, $x2p, $y1 , $x2m, $y1, $color);
+        imageline($this->img, (int)$x2p, (int)$y1, (int)$x2m, (int)$y1, (int)$color);
         if ($this->error_bar_shape == 'tee') {
             $e = $this->error_bar_size;
-            imageline($this->img, $x2p, $y1 - $e, $x2p, $y1 + $e, $color);
-            imageline($this->img, $x2m, $y1 - $e, $x2m, $y1 + $e, $color);
+            imageline($this->img, (int)$x2p, (int)($y1 - $e), (int)$x2p, (int)($y1 + $e), (int)$color);
+            imageline($this->img, (int)$x2m, (int)($y1 - $e), (int)$x2m, (int)($y1 + $e), (int)$color);
         }
         imagesetthickness($this->img, 1);
         return TRUE;
@@ -7269,11 +7276,11 @@ class PHPlot
         $y2m = $this->ytr($y - $error_minus);
 
         imagesetthickness($this->img, $this->error_bar_line_width);
-        imageline($this->img, $x1, $y2p , $x1, $y2m, $color);
+        imageline($this->img, (int)$x1, (int)$y2p, (int)$x1, (int)$y2m, (int)$color);
         if ($this->error_bar_shape == 'tee') {
             $e = $this->error_bar_size;
-            imageline($this->img, $x1 - $e, $y2p, $x1 + $e, $y2p, $color);
-            imageline($this->img, $x1 - $e, $y2m, $x1 + $e, $y2m, $color);
+            imageline($this->img, (int)($x1 - $e), (int)$y2p, (int)($x1 + $e), (int)$y2p, (int)$color);
+            imageline($this->img, (int)($x1 - $e), (int)$y2m, (int)($x1 + $e), (int)$y2m, (int)$color);
         }
         imagesetthickness($this->img, 1);
         return TRUE;
@@ -7640,15 +7647,15 @@ class PHPlot
                 // Don't try to draw a 0 degree slice - it would make a full circle.
                 if ($arc_start_angle > $arc_end_angle) {
                     // Draw the slice
-                    ImageFilledArc($this->img, $xpos, $ypos+$h, $pie_width, $pie_height,
-                                   $arc_end_angle, $arc_start_angle, $slicecol, IMG_ARC_PIE);
+                    ImageFilledArc($this->img, (int)$xpos, (int)($ypos + $h), (int)$pie_width, (int)$pie_height,
+                                   (int)$arc_end_angle, (int)$arc_start_angle, (int)$slicecol, IMG_ARC_PIE);
 
                     // Processing to do only for the last (if shaded) or only (if unshaded) loop:
                     if ($h == 0) {
                         // Draw the pie segment outline (if enabled):
                         if ($do_borders) {
-                            ImageFilledArc($this->img, $xpos, $ypos, $pie_width, $pie_height,
-                                           $arc_end_angle, $arc_start_angle, $this->ndx_pieborder_color,
+                            ImageFilledArc($this->img, (int)$xpos, (int)$ypos, (int)$pie_width, (int)$pie_height,
+                                           (int)$arc_end_angle, (int)$arc_start_angle, (int)$this->ndx_pieborder_color,
                                            IMG_ARC_PIE | IMG_ARC_EDGED |IMG_ARC_NOFILL);
                         }
 
@@ -8649,7 +8656,7 @@ class PHPlot
                 }
 
                 // Draw candle body
-                $draw_body($this->img, $x_left, $yb1_pixels, $x_right, $yb2_pixels, $body_color);
+                $draw_body($this->img, (int)$x_left, (int)$yb1_pixels, (int)$x_right, (int)$yb2_pixels, (int)$body_color);
 
                 // Draw upper and lower wicks, if they have height. (In device coords, that's dY<0)
                 imagesetthickness($this->img, $wick_thickness);
@@ -8719,7 +8726,7 @@ class PHPlot
 
                 if (is_numeric($y_now = $this->data[$row][$rec])) {      //Allow for missing Y data
                     $y = $this->ytr($y_now);
-                    $z = (double)$this->data[$row][$rec+1]; // Z is required if Y is present.
+                    $z = (float)$this->data[$row][$rec+1]; // Z is required if Y is present.
                     $size = (int)($f_size * $z + $b_size);  // Calculate bubble size
 
                     // Select the color:
@@ -8761,7 +8768,7 @@ class PHPlot
         $width1 = max($this->boxes_min_width, min($this->boxes_max_width,
                      (int)($this->boxes_frac_width * $this->plot_area_width / $this->num_data_rows)));
         // This is the half-width of the upper and lower T's and the ends of the whiskers:
-        $width2 = $this->boxes_t_width * $width1;
+        $width2 = (int)round($this->boxes_t_width * $width1);
 
         // A box plot can use up to 3 different line widths:
         list($box_thickness, $belt_thickness, $whisker_thickness) = $this->line_widths;

--- a/tagsets/class.phplot.php
+++ b/tagsets/class.phplot.php
@@ -2044,7 +2044,7 @@ class PHPlot
             $ry = $qy + $r10 * $width_factor + $r11 * $font_height;
 
             // Finally, draw the text:
-            ImageTTFText($this->img, $font_size, $angle, $rx, $ry, $color, $font_file, $lines[$i]);
+            ImageTTFText($this->img, $font_size, $angle, (int)$rx, (int)$ry, (int)$color, $font_file, $lines[$i]);
 
             // Step to position of next line.
             // This is a rotation of (x=0,y=height+line_spacing) by $angle:
@@ -2588,7 +2588,7 @@ class PHPlot
      * Additional values in $args[] depend on the formatting type. All further paramters except
      * for the callback are optional.
      * For type='data': $args[1] = precision, $args[2] = prefix, $args[3] = suffix.
-     * For type 'time': $args[1] = format string for strftime().
+     * For type 'time': $args[1] = format string for date().
      * For type 'printf': $args[1:3] = 1, 2, or 3 format strings for sprintf().
      * For type 'custom': $args[1] = the callback (required), $args[2] = pass-through argument.
      *
@@ -2617,7 +2617,7 @@ class PHPlot
             if (isset($args[1]))
                 $format['time_format'] = $args[1];
             elseif (!isset($format['time_format']))
-                $format['time_format'] = '%H:%M:%S';
+                $format['time_format'] = 'H:i:s';
             break;
 
         case 'printf':
@@ -2734,7 +2734,7 @@ class PHPlot
      * SetXLabelType('time'). But since you can pass the formatting string
      * to SetXLabelType() also, there is no need to use SetXTimeFormat().
      *
-     * @param string $which_xtf  Formatting string to use (see PHP function strftime())
+     * @param string $which_xtf  Formatting string to use (see PHP function date())
      * @return bool  True always
      */
     function SetXTimeFormat($which_xtf)
@@ -2750,7 +2750,7 @@ class PHPlot
      * SetYLabelType('time'). But since you can pass the formatting string
      * to SetYLabelType() also, there is no need to use SetYTimeFormat().
      *
-     * @param string $which_ytf  Formatting string (see PHP function strftime())
+     * @param string $which_ytf  Formatting string (see PHP function date())
      * @return bool  True always
      */
     function SetYTimeFormat($which_ytf)
@@ -5378,7 +5378,7 @@ class PHPlot
                            . $format['suffix'];
                 break;
             case 'time':
-                $which_lab = strftime($format['time_format'], $which_lab);
+                $which_lab = date($format['time_format'], $which_lab);
                 break;
             case 'printf':
                 if (!is_array($format['printf_format'])) {
@@ -7193,7 +7193,7 @@ class PHPlot
         }
 
         // Draw the bar
-        ImageFilledRectangle($this->img, $x1, $y1, $x2, $y2, $data_color);
+        ImageFilledRectangle($this->img, (int)$x1, (int)$y1, (int)$x2, (int)$y2, (int)$data_color);
 
         // Draw a shade, if shading is on.
         if (isset($shade_color)) {

--- a/tagsets/class.phplot.php
+++ b/tagsets/class.phplot.php
@@ -787,10 +787,6 @@ class PHPlot
         if (!$im)
             return FALSE;  // GetImage already produced an error message.
 
-        // Deallocate any resources previously allocated
-        if (isset($this->img))
-            imagedestroy($this->img);
-
         $this->img = $im;
 
         // Do not overwrite the input file with the background color.
@@ -5819,10 +5815,6 @@ class PHPlot
 
         // Copy the temporary image onto the final one.
         imagecopy($this->img, $tmp, $xorig, $yorig, 0,0, $width, $height);
-
-        // Free resources
-        imagedestroy($tmp);
-        imagedestroy($im);
 
         return TRUE;
     }

--- a/tagsets/csvoutput.php
+++ b/tagsets/csvoutput.php
@@ -89,13 +89,13 @@ function csvoutput__make_part_list($experiment_id,$session_id="",$pstatus="",$fo
 
     $fp = fopen('php://output', 'w');
     $headers_csv = participant__get_result_table_headcells_pdf($cols);
-    fputcsv($fp, $headers_csv);
+    fputcsv($fp, $headers_csv, ',', '"', '\\');
     $pnr=0;
     foreach ($participants as $p) {
         $pnr++;
         $p['order_number']=$pnr;
         $part_csv = participant__get_result_table_row_pdf($cols,$p);
-        fputcsv($fp, $part_csv);
+        fputcsv($fp, $part_csv, ',', '"', '\\');
     }
     fclose($fp);
 

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -888,7 +888,7 @@ function process_mail_template($template,$vararray) {
     foreach ($vars as $key) {
         $i=0;
         foreach ($output as $outputline) {
-            $output[$i]=str_replace("#".$key."#",$vararray[$key],$output[$i]);
+            $output[$i]=str_replace("#".$key."#",($vararray[$key] ?? ''),$output[$i]);
             $i++;
         }
     }

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -936,7 +936,7 @@ function experimentmail__send_invitations_to_queue($experiment_id,$whom="not-inv
         case "all":             $aquery=""; break;
         default:                $aquery=" AND ".table('participants').".participant_id='0' ";
     }
-    mt_srand((double)microtime()*1000000);
+    mt_srand((float)microtime()*1000000);
     $order="ORDER BY rand(".mt_rand().") ";
     $now=time();
     $status_query=participant_status__get_pquery_snippet("eligible_for_experiments");

--- a/tagsets/html_stuff.php
+++ b/tagsets/html_stuff.php
@@ -543,7 +543,7 @@ function html__build_menu($menu,$logged_in,$current_user_data_box,$orientation="
                 $item['content']='<FONT class="menu_title" color="'.$color['menu_title'].'">'.$current_user_data_box.'</FONT>';
                 $item['bg']='';
             } else {
-                if (preg_match("/^".$item['menu_area']."/i",$menu__area)) $item['bg']=' bgcolor="'.$color['menu_item_highlighted_background'].'"';
+                if (preg_match("/^".$item['menu_area']."/i",(string)$menu__area)) $item['bg']=' bgcolor="'.$color['menu_item_highlighted_background'].'"';
                 else $item['bg']="";
                 if (!isset($item['link'])) $link='';
                 elseif (substr($item['link'],0,1)=='/') $link=$settings__root_url.$item['link'].$addp;

--- a/tagsets/html_stuff.php
+++ b/tagsets/html_stuff.php
@@ -156,10 +156,10 @@ function html__show_style_header($area='public',$title="") {
     $tpl=file_get_contents('../style/'.$settings['style'].'/html_header.php');
 
     // fill colors
-    foreach ($color as $k=>$o) $tpl=str_replace("#".$k."#",$o,$tpl);
+    foreach ($color as $k=>$o) $tpl=str_replace("#".$k."#",($o ?? ''),$tpl);
 
     // add title
-    $tpl=str_replace("#title#",$title,$tpl);
+    $tpl=str_replace("#title#",($title ?? ''),$tpl);
 
 
     // prepare menu
@@ -205,7 +205,7 @@ function html__show_style_footer($area='public') {
     $tpl=file_get_contents('../style/'.$settings['style'].'/html_footer.php');
 
     // fill colors
-    foreach ($color as $k=>$o) $tpl=str_replace("#".$k."#",$o,$tpl);
+    foreach ($color as $k=>$o) $tpl=str_replace("#".$k."#",($o ?? ''),$tpl);
 
     // fill in language terms if any
         $pattern="/lang\[([^\]]+)\]/i";

--- a/tagsets/orsee_mysql.php
+++ b/tagsets/orsee_mysql.php
@@ -77,6 +77,7 @@ function id_array_to_par_array($id_array,$parname='id') {
 function or_query($query,$pars=array()) {
     global $db;
     $id=start_query_timer($query,$pars);
+    $stmt=false;
     try {
         if (is_array($pars) && count($pars)>0) {
             // parametrized query
@@ -92,6 +93,7 @@ function or_query($query,$pars=array()) {
         }
     } catch (PDOException $e) {
         show_message('<pre>Query error: ' . $e->getMessage(). "\nQuery: ".$query."</pre>");
+        $stmt=false;
     }
     $end=stop_query_timer($id);
     return $stmt;
@@ -139,6 +141,7 @@ function stop_query_timer($id) {
 
 
 function pdo_fetch_assoc($stmt) {
+    if (!$stmt) return false;
     return $stmt->fetch(PDO::FETCH_ASSOC);
 }
 

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -447,7 +447,7 @@ function load_form_template($tpl_name,$out,$template='current_template') {
 
 
     // fill in the vars
-    foreach ($out as $k=>$o) $tpl=str_replace("#".$k."#",$o,$tpl);
+    foreach ($out as $k=>$o) $tpl=str_replace("#".$k."#",($o ?? ''),$tpl);
 
     // fill in language terms
         $pattern="/lang\[([^\]]+)\]/i";

--- a/tagsets/session_handler.php
+++ b/tagsets/session_handler.php
@@ -1,6 +1,36 @@
 <?php
 // part of orsee. see orsee.org
 
+class orsee_session_handler implements SessionHandlerInterface {
+    public function open(string $aSavaPath, string $aSessionName): bool {
+        return orsee_session_open($aSavaPath,$aSessionName);
+    }
+
+    public function close(): bool {
+        return orsee_session_close();
+    }
+
+    public function read(string $aKey): string {
+        return (string)orsee_session_read($aKey);
+    }
+
+    public function write(string $aKey, string $aVal): bool {
+        return orsee_session_write($aKey,$aVal);
+    }
+
+    public function destroy(string $aKey): bool {
+        return orsee_session_destroy($aKey);
+    }
+
+    public function gc(int $aMaxLifeTime): int {
+        return orsee_session_gc($aMaxLifeTime);
+    }
+}
+
+function orsee_session_register_handler() {
+    session_set_save_handler(new orsee_session_handler(), true);
+}
+
 function orsee_session_open($aSavaPath, $aSessionName) {
        global $aTime;
        orsee_session_gc( $aTime );
@@ -47,8 +77,8 @@ function orsee_session_gc( $aMaxLifeTime ) {
     if (!isset($aMaxLifeTime) || (!$aMaxLifeTime)) $aMaxLifeTime=60*60;
     $pars=array(':aMaxLifeTime'=>$aMaxLifeTime);
     $query = "DELETE FROM ".table('http_sessions')." WHERE UNIX_TIMESTAMP(NOW()) - UNIX_TIMESTAMP(LastUpdated) > :aMaxLifeTime";
-    or_query($query,$pars);
-    return true;
+    $done=or_query($query,$pars);
+    return pdo_num_rows($done);
 }
 
 

--- a/tagsets/stats.php
+++ b/tagsets/stats.php
@@ -750,7 +750,7 @@ function stats__get_participant_action_data($months_backward=12) {
             WHERE date_format(FROM_UNIXTIME(timestamp),'%Y%m')>=date_format(FROM_UNIXTIME(".$first_date_unixtime."),'%Y%m')
             AND action IN ('".implode("','",$actions)."')
             GROUP BY action, yearmonth
-            ORDER BY timestamp DESC";
+            ORDER BY yearmonth DESC, action";
     $result=or_query($query);
     while ($line=pdo_fetch_assoc($result)) {
         $nums[$line['action']][$line['yearmonth']]=$line['nractions'];


### PR DESCRIPTION
A few functions have been deprecated in recent PHP8 versions. This fixes error messages in ORSEE.
- Updated session_set_save_handler() to modern callback style (PHP 8.1+).
- Replaced deprecated utf8_encode() (PHP 8.2+).
- Fixed str_replace() calls where null was passed to $replace (deprecated in PHP 8).
- Fixed undefined array key access (QUERY_STRING) in admin/header.php.
- Replaced deprecated non-canonical type casts (double), (integer), (boolean) with canonical forms.
- Added explicit escape parameter to fputcsv() (required in newer PHP versions).
- Hardened SQL GROUP BY usage in stats query to avoid strict mode warnings.
- Replaced deprecated strftime() usage in PHPLot (PHP 8.1+).
- Improved type safety in PHPlot integration (explicit integer casting for GD functions).

None of these changes affects the database. All are rather minor and do not add new functionality.