### PR TITLE
Truncating "target" in cron logging to varchar() column size.

### DIFF
--- a/tagsets/cronjobs.php
+++ b/tagsets/cronjobs.php
@@ -81,6 +81,16 @@ function cron__save_and_log_job($cronjob,$now="",$target="") {
         WHERE job_name= :job_name";
     $done=or_query($query,$pars);
 
+    // Cron log target column is VARCHAR(255); keep logs writable in strict SQL mode.
+    $target=(string)$target;
+    $target_max_length=255;
+    $target_suffix='TRUNC';
+    $target_suffix_length=strlen($target_suffix);
+    $target_length=mb_strlen($target,'UTF-8');
+    if ($target_length>$target_max_length) {
+        $target=mb_substr($target,0,$target_max_length-$target_suffix_length,'UTF-8').$target_suffix;
+    }
+
     $done=log__cron_job($cronjob,$target,$now,$id);
     return $done;
 


### PR DESCRIPTION
Some cron jobs create "target" texts that are larger than the varchar(250) column in the log table. With newer MySQL versions which uses "strict" as a default, this leads to error messages. This fix truncates log "target" to 255 characters for cron jobs. Other log actions do not create such long strings, so no action needed there.

This fix does not affect the database. In later major versions, we may redefine the "target" column to "text".

Fixes #358 