### PR TITLE
Adding OAuth2 capability to PHPmailer integration

### DIFF
--- a/admin/options_main.php
+++ b/admin/options_main.php
@@ -20,6 +20,7 @@ if ($proceed) {
     if (check_allow('regular_tasks_show')) $optionlist[]='<A HREF="cronjob_main.php" class="option">'.oicon('history').lang('regular_tasks').'</A>';
     if (check_allow('admin_type_edit')) $optionlist[]='<A HREF="admin_type_show.php" class="option">'.oicon('graduation-cap').lang('user_types_and_privileges').'</A>';
     if (check_allow('admin_edit')) $optionlist[]='<A HREF="admin_show.php" class="option">'.oicon('users').lang('user_management').'</A>';
+    if (check_allow('settings_oauth_edit')) $optionlist[]='<A HREF="options_oauth_tokens.php" class="option">'.oicon('key').lang('configure_oauth_tokens').'</A>';
     options__show_main_section(lang('system_setup'),$optionlist);
 
     $optionlist=array();

--- a/admin/options_oauth_tokens.php
+++ b/admin/options_oauth_tokens.php
@@ -1,0 +1,244 @@
+<?php
+// part of orsee. see orsee.org
+ob_start();
+
+$title="configure_oauth_tokens";
+$menu__area="options_main";
+include ("header.php");
+if ($proceed) {
+    $allow=check_allow('settings_oauth_edit','options_main.php');
+}
+
+if ($proceed) {
+    $allow_edit=$allow;
+    $identity_map=experimentmail__oauth_identity_map();
+    if (!is_array($identity_map) || count($identity_map)<1) {
+        $identity_map=array("*"=>experimentmail__oauth_normalize_identity_config("*",array()));
+    }
+    $identity_keys=array_keys($identity_map);
+    sort($identity_keys);
+    $selected_identity_key=(isset($_REQUEST['identity_key']) ? trim((string)$_REQUEST['identity_key']) : "");
+    if ($selected_identity_key==="" && isset($_REQUEST['state']) && is_string($_REQUEST['state'])) {
+        $state_in=trim((string)$_REQUEST['state']);
+        if (strpos($state_in,'orsee:')===0) {
+            $payload_b64=substr($state_in,6);
+            $payload_raw=base64_decode(strtr($payload_b64,'-_','+/'));
+            $payload=json_decode((string)$payload_raw,true);
+            if (is_array($payload) && isset($payload['k']) && is_string($payload['k'])) {
+                $selected_identity_key=trim($payload['k']);
+            }
+        }
+    }
+    if ($selected_identity_key==="" || !isset($identity_map[$selected_identity_key])) {
+        $selected_identity_key=$identity_keys[0];
+    }
+    $oauth_config=$identity_map[$selected_identity_key];
+    $default_redirect_uri=$settings__root_url."/admin/options_oauth_tokens.php";
+    $redirect_uri=$default_redirect_uri;
+    $state_token=experimentmail__oauth_default_state();
+    $state_payload=array('k'=>$selected_identity_key,'t'=>$state_token);
+    $state="orsee:".rtrim(strtr(base64_encode(json_encode($state_payload)),'+/','-_'),'=');
+    $authorization_url="";
+    $token_response_json="";
+    $stored_token=experimentmail__oauth_tokens__load('smtp_send',$oauth_config['identity'],$oauth_config['provider']);
+    $has_config_refresh_token=(isset($oauth_config['refresh_token']) && trim((string)$oauth_config['refresh_token'])!=="");
+    $has_stored_refresh_token=(is_array($stored_token) && isset($stored_token['refresh_token']) && trim((string)$stored_token['refresh_token'])!=="");
+    $has_refresh_token_available=($has_config_refresh_token || $has_stored_refresh_token);
+    $oauth_missing_fields=array();
+    if (!isset($oauth_config['identity']) || trim((string)$oauth_config['identity'])==="") {
+        $oauth_missing_fields[]='identity';
+    }
+    if (!isset($oauth_config['client_id']) || trim((string)$oauth_config['client_id'])==="") {
+        $oauth_missing_fields[]='client_id';
+    }
+    if (!isset($oauth_config['client_secret']) || trim((string)$oauth_config['client_secret'])==="") {
+        $oauth_missing_fields[]='client_secret';
+    }
+
+    if ($allow_edit && isset($_REQUEST['do_action']) && $_REQUEST['do_action']=="generate_url") {
+        try {
+            $authorization_url=experimentmail__oauth_authorization_url($oauth_config,$redirect_uri,$state);
+            if (!headers_sent()) {
+                header("Location: ".$authorization_url);
+                exit;
+            }
+            message(lang('oauth_msg_url_generated_no_redirect'),"error_message");
+        } catch (Exception $e) {
+            message(lang('oauth_msg_url_generation_failed').": ".$e->getMessage(),"error_message");
+        }
+    }
+
+    if ($allow_edit && isset($_REQUEST['do_action']) && $_REQUEST['do_action']=="exchange_code") {
+        $authorization_code=(isset($_REQUEST['authorization_code']) ? trim((string)$_REQUEST['authorization_code']) : "");
+        if ($authorization_code==="") {
+            message(lang('oauth_msg_please_provide_authorization_code'),"error_message");
+        } else {
+            try {
+                $token_response=experimentmail__oauth_exchange_authorization_code($oauth_config,$redirect_uri,$authorization_code);
+                $saved=experimentmail__oauth_store_token_response($oauth_config,$token_response,'smtp_send');
+                $token_response_json=json_encode($token_response,JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+                if (!$saved) {
+                    message(lang('oauth_msg_token_exchange_storing_failed'),"error_message");
+                } else {
+                    message(lang('oauth_msg_token_stored_for_identity')." ".$oauth_config['identity'].".");
+                }
+            } catch (Exception $e) {
+                message(lang('oauth_msg_code_exchange_failed').": ".$e->getMessage(),"error_message");
+            }
+        }
+    }
+
+    if ($allow_edit && (!isset($_REQUEST['do_action']) || $_REQUEST['do_action']!=="exchange_code")
+        && isset($_REQUEST['code']) && trim((string)$_REQUEST['code'])!=="") {
+        $authorization_code=trim((string)$_REQUEST['code']);
+        try {
+            $token_response=experimentmail__oauth_exchange_authorization_code($oauth_config,$redirect_uri,$authorization_code);
+            $saved=experimentmail__oauth_store_token_response($oauth_config,$token_response,'smtp_send');
+            $token_response_json=json_encode($token_response,JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+            if (!$saved) {
+                message(lang('oauth_msg_auto_token_exchange_storing_failed'),"error_message");
+            } else {
+                message(lang('oauth_msg_auto_token_stored_for_identity')." ".$oauth_config['identity'].".");
+            }
+        } catch (Exception $e) {
+            message(lang('oauth_msg_auto_code_exchange_failed').": ".$e->getMessage(),"error_message");
+        }
+    } elseif (isset($_REQUEST['error']) && trim((string)$_REQUEST['error'])!=="") {
+        $oauth_error=trim((string)$_REQUEST['error']);
+        $oauth_error_desc=(isset($_REQUEST['error_description']) ? trim((string)$_REQUEST['error_description']) : "");
+        if ($oauth_error_desc!=="") {
+            message(lang('oauth_msg_provider_returned_error').": ".$oauth_error." (".$oauth_error_desc.")","error_message");
+        } else {
+            message(lang('oauth_msg_provider_returned_error').": ".$oauth_error,"error_message");
+        }
+    }
+
+    if ($allow_edit && isset($_REQUEST['do_action']) && $_REQUEST['do_action']=="refresh_test") {
+        if (!$has_refresh_token_available) {
+            message(lang('oauth_msg_no_refresh_token_available'),"error_message");
+        } else {
+            try {
+                $access_token=experimentmail__oauth_get_valid_access_token($oauth_config,'smtp_send');
+                if ($access_token && strlen($access_token)>10) {
+                    message(lang('oauth_msg_refresh_test_succeeded'));
+                } else {
+                    message(lang('oauth_msg_refresh_test_failed_no_access_token'),"error_message");
+                }
+            } catch (Exception $e) {
+                message(lang('oauth_msg_refresh_test_failed').": ".$e->getMessage(),"error_message");
+            }
+        }
+        $stored_token=experimentmail__oauth_tokens__load('smtp_send',$oauth_config['identity'],$oauth_config['provider']);
+        $has_stored_refresh_token=(is_array($stored_token) && isset($stored_token['refresh_token']) && trim((string)$stored_token['refresh_token'])!=="");
+        $has_refresh_token_available=($has_config_refresh_token || $has_stored_refresh_token);
+    }
+}
+
+if ($proceed) {
+    echo '<center>';
+    show_message();
+
+    echo '<TABLE class="or_formtable" style="width: 90%; max-width: 1100px;">
+            ';
+
+    echo '<TR><TD colspan="2">
+            This page uses OAuth identity definitions from <code>config/settings.php</code> (<code>$settings__phpmailer_smtp_oauth_identities</code>).
+            You can authenticate the selected identity here with the provider.
+            Tokens are currently stored for SMTP sending (<code>purpose=smtp_send</code>).
+          </TD></TR>';
+
+    echo '<TR><TD colspan="2"><hr></TD></TR>';
+    echo '<TR><TD colspan="2"><B>Step 1: Generate authorization URL (skip if you already have an authorization code)</B></TD></TR>';
+
+    echo '<FORM action="options_oauth_tokens.php" method="post">';
+    echo '<INPUT type="hidden" name="do_action" value="generate_url">';
+    echo '<TR><TD>Configured identity</TD><TD>';
+    echo '<SELECT name="identity_key">';
+    foreach ($identity_keys as $k) {
+        echo '<OPTION value="'.htmlspecialchars($k).'"';
+        if ($k===$selected_identity_key) {
+            echo ' selected';
+        }
+        echo '>'.htmlspecialchars($k).'</OPTION>';
+    }
+    echo '</SELECT>';
+    echo '</TD></TR>';
+
+    echo '<TR><TD>Provider</TD><TD>'.htmlspecialchars((string)$oauth_config['provider']).'</TD></TR>';
+    echo '<TR><TD>OAuth identity</TD><TD>'.htmlspecialchars((string)$oauth_config['identity']).'</TD></TR>';
+    echo '<TR><TD>Token endpoint</TD><TD>'.htmlspecialchars((string)$oauth_config['token_endpoint']).'</TD></TR>';
+    echo '<TR><TD>Scopes</TD><TD>'.htmlspecialchars((string)$oauth_config['scopes']).'</TD></TR>';
+    echo '<TR><TD>Redirect URI</TD><TD>'.htmlspecialchars($redirect_uri).'</TD></TR>';
+    echo '<TR><TD>State</TD><TD>'.htmlspecialchars($state).'</TD></TR>';
+    if (count($oauth_missing_fields)>0) {
+        echo '<TR><TD>Configuration warning</TD><TD><FONT color="red">This identity entry in config/settings.php is incomplete. Missing: '.htmlspecialchars(implode(", ",$oauth_missing_fields)).'.</FONT></TD></TR>';
+    }
+    echo '<TR><TD></TD><TD><INPUT class="button" type="submit" value="'.lang('oauth_authenticate_with_provider').'"';
+    if (count($oauth_missing_fields)>0) {
+        echo ' disabled';
+    }
+    echo '></TD></TR>';
+    echo '</FORM>';
+
+    if ($authorization_url!=="") {
+        echo '<TR><TD>Authorization URL</TD><TD><TEXTAREA rows="5" cols="110" readonly>'.htmlspecialchars($authorization_url).'</TEXTAREA></TD></TR>';
+    }
+
+    echo '<TR><TD colspan="2"><hr></TD></TR>';
+    echo '<TR><TD colspan="2">';
+    echo '<details>';
+    echo '<summary><B>Advanced: Manual code exchange (fallback)</B></summary>';
+    echo '<BR>';
+    echo '<FORM action="options_oauth_tokens.php" method="post">';
+    echo '<INPUT type="hidden" name="do_action" value="exchange_code">';
+    echo '<INPUT type="hidden" name="identity_key" value="'.htmlspecialchars($selected_identity_key).'">';
+    echo '<TABLE width="100%">';
+    echo '<TR><TD width="220">Authorization code</TD><TD><TEXTAREA name="authorization_code" rows="4" cols="100">';
+    if (isset($_REQUEST['code']) && trim((string)$_REQUEST['code'])!=="") {
+        echo htmlspecialchars(trim((string)$_REQUEST['code']));
+    }
+    echo '</TEXTAREA></TD></TR>';
+    echo '<TR><TD></TD><TD><INPUT class="button" type="submit" value="'.lang('oauth_exchange_code').'"></TD></TR>';
+    echo '</TABLE>';
+    echo '</FORM>';
+    echo '</details>';
+    echo '</TD></TR>';
+
+    echo '<TR><TD colspan="2"><hr></TD></TR>';
+
+    echo '<FORM action="options_oauth_tokens.php" method="post">';
+    echo '<INPUT type="hidden" name="do_action" value="refresh_test">';
+    echo '<INPUT type="hidden" name="identity_key" value="'.htmlspecialchars($selected_identity_key).'">';
+    echo '<TR><TD>Test current OAuth refresh token</TD><TD>';
+    echo 'Use this to verify that ORSEE can refresh and get a valid access token for the selected identity.<BR>';
+    echo 'If the test fails, you need to reauthorize to obtain a new OAuth refresh token.<BR><BR>';
+    if (is_array($stored_token)) {
+        $exp=(isset($stored_token['access_token_expires_at']) ? (int)$stored_token['access_token_expires_at'] : 0);
+        echo 'Refresh token: '.((isset($stored_token['refresh_token']) && trim((string)$stored_token['refresh_token'])!=="") ? 'yes' : 'no').'<BR>';
+        echo 'Access token cached: '.((isset($stored_token['access_token']) && trim((string)$stored_token['access_token'])!=="") ? 'yes' : 'no').'<BR>';
+        echo 'Access token expires: '.($exp>0 ? ortime__format($exp) : 'n/a');
+    } else {
+        echo 'No token currently stored for this identity.';
+    }
+    echo '</TD></TR>';
+    echo '<TR><TD></TD><TD><INPUT class="button" type="submit" value="'.lang('oauth_test_current_refresh_token').'"';
+    if (!$has_refresh_token_available) {
+        echo ' disabled';
+    }
+    echo '></TD></TR>';
+    echo '</FORM>';
+
+    echo '</TABLE>';
+    echo '<BR><BR><A href="options_main.php">'.icon('back').' '.lang('back').'</A><BR><BR>';
+    echo '</center>';
+
+    if (!$allow_edit) {
+        echo '<script type="text/javascript">
+                $(".button").attr("disabled", true);
+                $(":input").attr("disabled", true);
+              </script>';
+    }
+}
+
+include ("footer.php");
+?>

--- a/config/dbupdates.php
+++ b/config/dbupdates.php
@@ -389,5 +389,213 @@ $system__database_upgrades[]=array(
     )
 );
 
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'query',
+'specs'=> array(
+    'query_code'=>"CREATE TABLE IF NOT EXISTS TABLE(oauth_tokens) (
+        token_id int(20) NOT NULL AUTO_INCREMENT,
+        purpose varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+        identity_email varchar(200) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+        provider varchar(40) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+        refresh_token mediumtext COLLATE utf8_unicode_ci,
+        access_token mediumtext COLLATE utf8_unicode_ci,
+        access_token_expires_at int(20) NOT NULL DEFAULT '0',
+        created_at int(20) NOT NULL DEFAULT '0',
+        updated_at int(20) NOT NULL DEFAULT '0',
+        PRIMARY KEY (token_id),
+        UNIQUE KEY identity_purpose_provider (purpose,identity_email,provider)
+    ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci"
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'configure_oauth_tokens',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Configure OAuth Tokens','de'=>'OAuth-Tokens konfigurieren')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_authenticate_with_provider',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Authenticate With Provider','de'=>'Mit Provider authentifizieren')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_exchange_code',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Exchange Authorization Code','de'=>'Autorisierungscode austauschen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_test_current_refresh_token',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Test current OAuth refresh token','de'=>'Aktuelles OAuth-Refresh-Token testen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_url_generated_no_redirect',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Authorization URL generated, but automatic redirect was not possible. Please open the URL below.','de'=>'Autorisierungs-URL wurde erstellt, aber die automatische Weiterleitung war nicht möglich. Bitte öffnen Sie die URL unten.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_url_generation_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'OAuth URL generation failed','de'=>'Erstellung der OAuth-URL fehlgeschlagen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_please_provide_authorization_code',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Please provide an authorization code.','de'=>'Bitte geben Sie einen Autorisierungscode ein.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_token_exchange_storing_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Token exchange succeeded, but storing token failed.','de'=>'Token-Austausch war erfolgreich, aber das Speichern des Tokens ist fehlgeschlagen.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_token_stored_for_identity',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'OAuth token stored for identity','de'=>'OAuth-Token gespeichert für Identität')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_code_exchange_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'OAuth code exchange failed','de'=>'OAuth-Code-Austausch fehlgeschlagen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_auto_token_exchange_storing_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Automatic token exchange succeeded, but storing token failed.','de'=>'Automatischer Token-Austausch war erfolgreich, aber das Speichern des Tokens ist fehlgeschlagen.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_auto_token_stored_for_identity',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'OAuth token stored automatically for identity','de'=>'OAuth-Token automatisch gespeichert für Identität')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_auto_code_exchange_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Automatic OAuth code exchange failed','de'=>'Automatischer OAuth-Code-Austausch fehlgeschlagen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_provider_returned_error',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'OAuth provider returned error','de'=>'OAuth-Provider hat einen Fehler zurückgegeben')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_no_refresh_token_available',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'No OAuth refresh token is available for the selected identity. Please authenticate with provider first.','de'=>'Für die ausgewählte Identität ist kein OAuth-Refresh-Token verfügbar. Bitte authentifizieren Sie sich zuerst beim Provider.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_refresh_test_succeeded',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Refresh test succeeded. Access token received.','de'=>'Refresh-Test erfolgreich. Access-Token erhalten.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_refresh_test_failed_no_access_token',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Refresh test failed: no access token returned.','de'=>'Refresh-Test fehlgeschlagen: kein Access-Token zurückgegeben.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'oauth_msg_refresh_test_failed',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Refresh test failed','de'=>'Refresh-Test fehlgeschlagen')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026031100',
+'type'=>'new_admin_right',
+'specs'=> array(
+    'right_name'=>'settings_oauth_edit',
+    'admin_types'=>array('admin','developer','installer')
+    )
+);
 
 ?>

--- a/config/system.php
+++ b/config/system.php
@@ -2,7 +2,7 @@
 // part of orsee. see orsee.org
 // THIS FILE WILL CHANGE FROM VERSION TO VERSION. BETTER NOT EDIT.
 $system__version="3.2.0";
-$system__database_version=2024031100;
+$system__database_version=2026031004;
 
 // implemented experiment types
 $system__experiment_types=array('laboratory','online-survey','internet');
@@ -175,6 +175,7 @@ $system__admin_rights=array(
 "session_nonempty_delete:delete a session independent of participant signups:experiment_show,session_edit",
 "session_send_reminder:send session reminder manually:experiment_show,experiment_show_participants",
 "settings_edit:edit general settings and defaults",
+"settings_oauth_edit:configure OAuth token settings",
 "settings_edit_colors:edit color values for ORSEE styles",
 "settings_view:view general settings and defaults",
 "settings_view_colors:view color values for ORSEE styles",

--- a/install/settings-dist.php
+++ b/install/settings-dist.php
@@ -52,16 +52,6 @@ $site__database_ssl_ca='/etc/mysql/ssl/ca-cert.pem';
 // List of timezones: http://php.net/manual/en/timezones.php
 date_default_timezone_set("Australia/Sydney");
 
-// OUTGOING EMAIL
-// Per default, ORSEE uses PHP's mail() function to send emails, and thus relies on
-// whatever is configured for PHP / the server. However, if this does not work properly
-// (e.g., the "envelope sender address" is not set correctly and mail delivery is refused
-// by the configured mail server, ORSEE can try to send emails directly via the local 
-// sendmail program (only on Linux servers). To do this, set "Type of sending emails" to
-// "indirect" in Options/General settings. ORSEE will look for the local sendmail program
-// in the following path.
-$settings__sendmail_path="/usr/sbin/sendmail";
-
 // INCOMING EMAIL MODULE
 // These settings are only needed when you plan to enable the email module
 // to retrieve emails from an external email account and process them in ORSEE
@@ -93,19 +83,46 @@ $settings__query_debugging_enabled="n";
 // Include path for tagsets. Leave as is, only change when you know what you are doing.
 ini_set("include_path",ini_get("include_path").":./tagsets:./../tagsets:./../../tagsets");
 
-// MAIL TRANSPORT
+
+// OUTGOING MAIL TRANSPORT
 // mail: use legacy transport (mail() / sendmail wrapper, configured in General Settings).
 // phpmailer: use PHPMailer + SMTP settings below.
 $settings__mail_transport="mail";
 
-// PHPMailer SMTP settings (used only when $settings__mail_transport = "phpmailer").
+// If $settings__mail_transport="mail", ORSEE uses PHP's mail() function to send emails,
+// which in turn relies on whatever is configured for PHP / the server. If this does not
+// work properly, ORSEE can try to send emails directly via the local sendmail program
+// (only on Linux servers). To do this, set "Type of sending emails" to "indirect" in 
+// Options/General settings. ORSEE will look for the local sendmail program in the following path.
+$settings__sendmail_path="/usr/sbin/sendmail";
+
+
+// If $settings__mail_transport="phpmailer", PHPMailer will use the following settings.
 $settings__phpmailer_host="your.smtp.mailserver.com";
 $settings__phpmailer_port=587;
 $settings__phpmailer_smtp_secure="tls"; // "", "tls", or "ssl"
-$settings__phpmailer_smtp_auth="n"; // y/n
+$settings__phpmailer_smtp_auth_type="password"; // "none", "password", or "oauth2"
 $settings__phpmailer_username="";
 $settings__phpmailer_password="";
 $settings__phpmailer_timeout=15;
 $settings__phpmailer_debug="n"; // y/n
+
+// If $settings__phpmailer_smtp_auth_type="oauth2", then PHPMailer will use OAuth2 authentication.
+// The following array allows to define multiple identities (different sender email addresses, 
+// potentially via different providers such as Google or Microsoft). However, you would typically 
+// just want to set up one identity for the main sender email address used in ORSEE.
+// Keys are sender addresses (or "*" as fallback).
+$settings__phpmailer_smtp_oauth_identities=array(
+    "*"=>array(
+        "provider"=>"google",
+        "identity"=>"",
+        "client_id"=>"",
+        "client_secret"=>"",
+        "refresh_token"=>"",
+        "token_endpoint"=>"", // empty = provider default endpoint
+        "scopes"=>"", // empty = provider defaults
+        "tenant"=>"common" // for Microsoft token endpoint construction
+    )
+);
 
 ?>

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -1,6 +1,34 @@
 <?php
 // part of orsee. see orsee.org
 
+namespace PHPMailer\PHPMailer {
+    if (!interface_exists('PHPMailer\\PHPMailer\\OAuthTokenProvider', false)) {
+        interface OAuthTokenProvider
+        {
+            public function getOauth64(): string;
+        }
+    }
+}
+
+namespace {
+
+class ORSEE_PHPMailer_OAuthTokenProvider implements \PHPMailer\PHPMailer\OAuthTokenProvider
+{
+    private $oauth_config;
+    private $purpose;
+
+    public function __construct($oauth_config, $purpose = 'smtp_send')
+    {
+        $this->oauth_config = $oauth_config;
+        $this->purpose = $purpose;
+    }
+
+    public function getOauth64(): string
+    {
+        return experimentmail__oauth_build_oauth64($this->oauth_config, $this->purpose);
+    }
+}
+
 function experimentmail__mail($recipient,$subject,$message,$headers,$env_sender="") {
     $headers .= "Content-Type: text/plain; charset=\"UTF-8\"\r\n";
     $message=html_entity_decode($message,ENT_COMPAT,'UTF-8');
@@ -26,7 +54,514 @@ function experimentmail__phpmailer_debug_log($line) {
     if (!experimentmail__phpmailer_debug_enabled()) {
         return;
     }
-    error_log("ORSEE PHPMailer: ".$line);
+    error_log("ORSEE PHPMailer: ".experimentmail__phpmailer_debug_sanitize((string)$line));
+}
+
+function experimentmail__phpmailer_debug_sanitize($line) {
+    if (!is_string($line) || $line==="") {
+        return "";
+    }
+    $line=preg_replace('/(AUTH XOAUTH2\\s+)[A-Za-z0-9+\\/=\\-_.]+/i','$1[oauth_token_hidden]',$line);
+    $line=preg_replace('/(auth=Bearer\\s+)[^\\x01\\r\\n\\s]+/i','$1[oauth_token_hidden]',$line);
+    $line=preg_replace('/(refresh_token=)[^&\\s]+/i','$1[oauth_refresh_token_hidden]',$line);
+    return $line;
+}
+
+function experimentmail__phpmailer_smtp_auth_type() {
+    global $settings__phpmailer_smtp_auth_type;
+    if (isset($settings__phpmailer_smtp_auth_type) && $settings__phpmailer_smtp_auth_type) {
+        $type=strtolower(trim((string)$settings__phpmailer_smtp_auth_type));
+        if ($type=="oauth2" || $type=="password" || $type=="none") {
+            return $type;
+        }
+    }
+    return "none";
+}
+
+function experimentmail__oauth_provider_defaults($provider,$tenant="common") {
+    $provider=strtolower(trim((string)$provider));
+    $defaults=array(
+        "provider"=>$provider,
+        "token_endpoint"=>"",
+        "auth_endpoint"=>"",
+        "scopes"=>""
+    );
+    if ($provider=="google") {
+        $defaults["token_endpoint"]="https://oauth2.googleapis.com/token";
+        $defaults["auth_endpoint"]="https://accounts.google.com/o/oauth2/v2/auth";
+        $defaults["scopes"]="https://mail.google.com/";
+    } elseif ($provider=="microsoft") {
+        $tenant=trim((string)$tenant);
+        if ($tenant==="") {
+            $tenant="common";
+        }
+        $defaults["token_endpoint"]="https://login.microsoftonline.com/".$tenant."/oauth2/v2.0/token";
+        $defaults["auth_endpoint"]="https://login.microsoftonline.com/".$tenant."/oauth2/v2.0/authorize";
+        $defaults["scopes"]="offline_access https://outlook.office.com/SMTP.Send";
+    }
+    return $defaults;
+}
+
+function experimentmail__oauth_default_state() {
+    return create_random_token("smtp_oauth_state");
+}
+
+function experimentmail__oauth_authorization_url($oauth_config,$redirect_uri,$state="") {
+    if (!is_array($oauth_config)) {
+        throw new RuntimeException("OAuth identity config is not valid.");
+    }
+    $provider=isset($oauth_config['provider']) ? strtolower(trim((string)$oauth_config['provider'])) : "";
+    $client_id=isset($oauth_config['client_id']) ? trim((string)$oauth_config['client_id']) : "";
+    $auth_endpoint=isset($oauth_config['auth_endpoint']) ? trim((string)$oauth_config['auth_endpoint']) : "";
+    $scopes=isset($oauth_config['scopes']) ? trim((string)$oauth_config['scopes']) : "";
+    $identity=isset($oauth_config['identity']) ? trim((string)$oauth_config['identity']) : "";
+
+    if ($provider==="") {
+        throw new RuntimeException("OAuth provider is missing.");
+    }
+    if ($client_id==="") {
+        throw new RuntimeException("OAuth client id is missing.");
+    }
+    if ($auth_endpoint==="") {
+        throw new RuntimeException("OAuth authorization endpoint is missing.");
+    }
+    if ($scopes==="") {
+        throw new RuntimeException("OAuth scopes are missing.");
+    }
+    if (!is_string($redirect_uri) || trim($redirect_uri)==="") {
+        throw new RuntimeException("OAuth redirect URI is missing.");
+    }
+    $redirect_uri=trim($redirect_uri);
+    if ($state==="") {
+        $state=experimentmail__oauth_default_state();
+    }
+
+    $pars=array(
+        'client_id'=>$client_id,
+        'response_type'=>'code',
+        'redirect_uri'=>$redirect_uri,
+        'scope'=>$scopes,
+        'state'=>$state
+    );
+    if ($provider==="google") {
+        $pars['access_type']='offline';
+        $pars['prompt']='consent';
+        $pars['include_granted_scopes']='true';
+    } elseif ($provider==="microsoft") {
+        $pars['response_mode']='query';
+    }
+    if ($identity!=="" && filter_var($identity,FILTER_VALIDATE_EMAIL)) {
+        $pars['login_hint']=$identity;
+    }
+    return $auth_endpoint."?".http_build_query($pars,'','&',PHP_QUERY_RFC3986);
+}
+
+function experimentmail__oauth_trim($value) {
+    return trim((string)$value);
+}
+
+function experimentmail__oauth_normalize_identity_config($identity_key,$raw) {
+    if (!is_array($raw)) {
+        $raw=array();
+    }
+    $provider=isset($raw["provider"]) ? experimentmail__oauth_trim($raw["provider"]) : "";
+    if ($provider==="") {
+        $provider="google";
+    }
+    if ($provider==="") {
+        $provider="google";
+    }
+    $tenant=isset($raw["tenant"]) ? experimentmail__oauth_trim($raw["tenant"]) : "";
+    if ($tenant==="") {
+        $tenant="common";
+    }
+    $defaults=experimentmail__oauth_provider_defaults($provider,$tenant);
+
+    $identity=isset($raw["identity"]) ? experimentmail__oauth_trim($raw["identity"]) : "";
+    if ($identity==="" && is_string($identity_key) && $identity_key!=="*" && filter_var($identity_key,FILTER_VALIDATE_EMAIL)) {
+        $identity=$identity_key;
+    }
+
+    $cfg=array();
+    $cfg["provider"]=$provider;
+    $cfg["tenant"]=$tenant;
+    $cfg["identity"]=strtolower($identity);
+    $cfg["client_id"]=isset($raw["client_id"]) ? experimentmail__oauth_trim($raw["client_id"]) : "";
+    $cfg["client_secret"]=isset($raw["client_secret"]) ? experimentmail__oauth_trim($raw["client_secret"]) : "";
+    $cfg["token_endpoint"]=isset($raw["token_endpoint"]) ? experimentmail__oauth_trim($raw["token_endpoint"]) : "";
+    if ($cfg["token_endpoint"]==="") {
+        $cfg["token_endpoint"]=$defaults["token_endpoint"];
+    }
+    $cfg["auth_endpoint"]=isset($raw["auth_endpoint"]) ? experimentmail__oauth_trim($raw["auth_endpoint"]) : "";
+    if ($cfg["auth_endpoint"]==="") {
+        $cfg["auth_endpoint"]=$defaults["auth_endpoint"];
+    }
+    $cfg["scopes"]=isset($raw["scopes"]) ? experimentmail__oauth_trim($raw["scopes"]) : "";
+    if ($cfg["scopes"]==="") {
+        $cfg["scopes"]=$defaults["scopes"];
+    }
+    $cfg["refresh_token"]=isset($raw["refresh_token"]) ? experimentmail__oauth_trim($raw["refresh_token"]) : "";
+    return $cfg;
+}
+
+function experimentmail__oauth_identity_map() {
+    global $settings__phpmailer_smtp_oauth_identities;
+    $map=array();
+    if (isset($settings__phpmailer_smtp_oauth_identities) && is_array($settings__phpmailer_smtp_oauth_identities)) {
+        foreach ($settings__phpmailer_smtp_oauth_identities as $key=>$raw) {
+            $map[strtolower(trim((string)$key))]=experimentmail__oauth_normalize_identity_config($key,$raw);
+        }
+    }
+    if (count($map)<1) {
+        $map["*"]=experimentmail__oauth_normalize_identity_config("*",array("provider"=>"google","tenant"=>"common"));
+    }
+    return $map;
+}
+
+function experimentmail__oauth_resolve_identity_config($from_address) {
+    $from_address=strtolower(trim((string)$from_address));
+    $map=experimentmail__oauth_identity_map();
+    if (isset($map[$from_address])) {
+        return $map[$from_address];
+    }
+    if (isset($map["*"])) {
+        $cfg=$map["*"];
+        if ($cfg["identity"]==="") {
+            $cfg["identity"]=$from_address;
+        }
+        return $cfg;
+    }
+    foreach ($map as $cfg) {
+        if (is_array($cfg) && isset($cfg["identity"]) && $cfg["identity"]!=="") {
+            return $cfg;
+        }
+    }
+    return false;
+}
+
+function experimentmail__oauth_tokens__load($purpose,$identity,$provider) {
+    if (!experimentmail__oauth_tokens__table_ready()) {
+        return false;
+    }
+    $purpose=trim((string)$purpose);
+    $identity=strtolower(trim((string)$identity));
+    $provider=strtolower(trim((string)$provider));
+    if ($purpose==="" || $identity==="" || $provider==="") {
+        return false;
+    }
+    $pars=array(':purpose'=>$purpose,':identity'=>$identity,':provider'=>$provider);
+    $query="SELECT * FROM ".table('oauth_tokens')."
+            WHERE purpose= :purpose
+            AND identity_email= :identity
+            AND provider= :provider";
+    $result=or_query($query,$pars);
+    if (!$result) {
+        return false;
+    }
+    $line=pdo_fetch_assoc($result);
+    if (!is_array($line)) {
+        return false;
+    }
+    return $line;
+}
+
+function experimentmail__oauth_tokens__save($purpose,$identity,$provider,$refresh_token,$access_token,$expires_at) {
+    if (!experimentmail__oauth_tokens__table_ready()) {
+        return false;
+    }
+    $purpose=trim((string)$purpose);
+    $identity=strtolower(trim((string)$identity));
+    $provider=strtolower(trim((string)$provider));
+    if ($purpose==="" || $identity==="" || $provider==="") {
+        return false;
+    }
+    $now=time();
+    $existing=experimentmail__oauth_tokens__load($purpose,$identity,$provider);
+    if ($existing && isset($existing['token_id'])) {
+        $pars=array(
+            ':token_id'=>$existing['token_id'],
+            ':refresh_token'=>(string)$refresh_token,
+            ':access_token'=>(string)$access_token,
+            ':access_token_expires_at'=>(int)$expires_at,
+            ':updated_at'=>$now
+        );
+        $query="UPDATE ".table('oauth_tokens')."
+                SET refresh_token= :refresh_token,
+                    access_token= :access_token,
+                    access_token_expires_at= :access_token_expires_at,
+                    updated_at= :updated_at
+                WHERE token_id= :token_id";
+        return or_query($query,$pars);
+    }
+    $pars=array(
+        ':purpose'=>$purpose,
+        ':identity'=>$identity,
+        ':provider'=>$provider,
+        ':refresh_token'=>(string)$refresh_token,
+        ':access_token'=>(string)$access_token,
+        ':access_token_expires_at'=>(int)$expires_at,
+        ':created_at'=>$now,
+        ':updated_at'=>$now
+    );
+    $query="INSERT INTO ".table('oauth_tokens')."
+            SET purpose= :purpose,
+                identity_email= :identity,
+                provider= :provider,
+                refresh_token= :refresh_token,
+                access_token= :access_token,
+                access_token_expires_at= :access_token_expires_at,
+                created_at= :created_at,
+                updated_at= :updated_at";
+    return or_query($query,$pars);
+}
+
+function experimentmail__oauth_tokens__table_ready() {
+    static $checked=false;
+    static $ready=false;
+    if ($checked) {
+        return $ready;
+    }
+    $checked=true;
+    $table_name=table('oauth_tokens');
+    $query="SHOW TABLES LIKE ".pdo_escape_string($table_name);
+    $result=or_query($query);
+    if (!$result) {
+        $ready=false;
+        return $ready;
+    }
+    $line=$result->fetch(\PDO::FETCH_NUM);
+    $ready=(is_array($line) && isset($line[0]) && $line[0]==$table_name);
+    return $ready;
+}
+
+function experimentmail__oauth_refresh_access_token($oauth_config,$refresh_token) {
+    $token_endpoint=isset($oauth_config['token_endpoint']) ? trim((string)$oauth_config['token_endpoint']) : "";
+    if ($token_endpoint==="") {
+        throw new RuntimeException("OAuth token endpoint is missing.");
+    }
+    $post=array(
+        'grant_type'=>'refresh_token',
+        'refresh_token'=>$refresh_token,
+        'client_id'=>isset($oauth_config['client_id']) ? (string)$oauth_config['client_id'] : ""
+    );
+    if (isset($oauth_config['client_secret']) && $oauth_config['client_secret']!=="") {
+        $post['client_secret']=(string)$oauth_config['client_secret'];
+    }
+    if (isset($oauth_config['provider']) && strtolower((string)$oauth_config['provider'])==="microsoft"
+        && isset($oauth_config['scopes']) && trim((string)$oauth_config['scopes'])!=="") {
+        $post['scope']=trim((string)$oauth_config['scopes']);
+    }
+    $ch=curl_init($token_endpoint);
+    curl_setopt_array($ch,array(
+        CURLOPT_POST=>true,
+        CURLOPT_POSTFIELDS=>http_build_query($post,'','&'),
+        CURLOPT_RETURNTRANSFER=>true,
+        CURLOPT_TIMEOUT=>15,
+        CURLOPT_HTTPHEADER=>array(
+            'Content-Type: application/x-www-form-urlencoded'
+        )
+    ));
+    $raw=curl_exec($ch);
+    if ($raw===false) {
+        $err=curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException("OAuth token request failed: ".$err);
+    }
+    $code=curl_getinfo($ch,CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    $json=json_decode($raw,true);
+    if ($code<200 || $code>=300 || !is_array($json) || !isset($json['access_token']) || !$json['access_token']) {
+        throw new RuntimeException("OAuth token response unexpected: HTTP ".$code);
+    }
+    return $json;
+}
+
+function experimentmail__oauth_exchange_authorization_code($oauth_config,$redirect_uri,$authorization_code) {
+    if (!is_array($oauth_config)) {
+        throw new RuntimeException("OAuth identity config is not valid.");
+    }
+    $provider=isset($oauth_config['provider']) ? strtolower(trim((string)$oauth_config['provider'])) : "";
+    $token_endpoint=isset($oauth_config['token_endpoint']) ? trim((string)$oauth_config['token_endpoint']) : "";
+    $client_id=isset($oauth_config['client_id']) ? trim((string)$oauth_config['client_id']) : "";
+    $client_secret=isset($oauth_config['client_secret']) ? trim((string)$oauth_config['client_secret']) : "";
+    $scopes=isset($oauth_config['scopes']) ? trim((string)$oauth_config['scopes']) : "";
+
+    if ($provider==="") {
+        throw new RuntimeException("OAuth provider is missing.");
+    }
+    if ($token_endpoint==="") {
+        throw new RuntimeException("OAuth token endpoint is missing.");
+    }
+    if ($client_id==="") {
+        throw new RuntimeException("OAuth client id is missing.");
+    }
+    if (!is_string($authorization_code) || trim($authorization_code)==="") {
+        throw new RuntimeException("OAuth authorization code is missing.");
+    }
+    if (!is_string($redirect_uri) || trim($redirect_uri)==="") {
+        throw new RuntimeException("OAuth redirect URI is missing.");
+    }
+
+    $post=array(
+        'grant_type'=>'authorization_code',
+        'client_id'=>$client_id,
+        'code'=>trim($authorization_code),
+        'redirect_uri'=>trim($redirect_uri)
+    );
+    if ($client_secret!=="") {
+        $post['client_secret']=$client_secret;
+    }
+    if ($provider==="microsoft" && $scopes!=="") {
+        $post['scope']=$scopes;
+    }
+
+    $ch=curl_init($token_endpoint);
+    curl_setopt_array($ch,array(
+        CURLOPT_POST=>true,
+        CURLOPT_POSTFIELDS=>http_build_query($post,'','&'),
+        CURLOPT_RETURNTRANSFER=>true,
+        CURLOPT_TIMEOUT=>20,
+        CURLOPT_HTTPHEADER=>array(
+            'Content-Type: application/x-www-form-urlencoded'
+        )
+    ));
+    $raw=curl_exec($ch);
+    if ($raw===false) {
+        $err=curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException("OAuth code exchange failed: ".$err);
+    }
+    $code=curl_getinfo($ch,CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    $json=json_decode($raw,true);
+    if ($code<200 || $code>=300 || !is_array($json) || !isset($json['access_token']) || !$json['access_token']) {
+        throw new RuntimeException("OAuth code exchange response unexpected: HTTP ".$code);
+    }
+    return $json;
+}
+
+function experimentmail__oauth_store_refresh_token($oauth_config,$refresh_token,$purpose='smtp_send') {
+    if (!is_array($oauth_config)) {
+        return false;
+    }
+    $identity=isset($oauth_config['identity']) ? strtolower(trim((string)$oauth_config['identity'])) : "";
+    $provider=isset($oauth_config['provider']) ? strtolower(trim((string)$oauth_config['provider'])) : "";
+    $refresh_token=trim((string)$refresh_token);
+    if ($identity==="" || $provider==="" || $refresh_token==="") {
+        return false;
+    }
+    $existing=experimentmail__oauth_tokens__load($purpose,$identity,$provider);
+    $access_token="";
+    $expires_at=0;
+    if ($existing) {
+        if (isset($existing['access_token'])) {
+            $access_token=(string)$existing['access_token'];
+        }
+        if (isset($existing['access_token_expires_at'])) {
+            $expires_at=(int)$existing['access_token_expires_at'];
+        }
+    }
+    return experimentmail__oauth_tokens__save($purpose,$identity,$provider,$refresh_token,$access_token,$expires_at);
+}
+
+function experimentmail__oauth_store_token_response($oauth_config,$token_response,$purpose='smtp_send') {
+    if (!is_array($oauth_config) || !is_array($token_response)) {
+        return false;
+    }
+    $identity=isset($oauth_config['identity']) ? strtolower(trim((string)$oauth_config['identity'])) : "";
+    $provider=isset($oauth_config['provider']) ? strtolower(trim((string)$oauth_config['provider'])) : "";
+    if ($identity==="" || $provider==="") {
+        return false;
+    }
+    $existing=experimentmail__oauth_tokens__load($purpose,$identity,$provider);
+    $refresh_token="";
+    if (isset($token_response['refresh_token']) && trim((string)$token_response['refresh_token'])!=="") {
+        $refresh_token=trim((string)$token_response['refresh_token']);
+    } elseif ($existing && isset($existing['refresh_token'])) {
+        $refresh_token=(string)$existing['refresh_token'];
+    }
+    $access_token=isset($token_response['access_token']) ? trim((string)$token_response['access_token']) : "";
+    if ($access_token==="" && $existing && isset($existing['access_token'])) {
+        $access_token=(string)$existing['access_token'];
+    }
+    $expires_in=isset($token_response['expires_in']) ? (int)$token_response['expires_in'] : 0;
+    $expires_at=0;
+    if ($expires_in>0) {
+        if ($expires_in<60) {
+            $expires_in=60;
+        }
+        $expires_at=time()+$expires_in;
+    } elseif ($existing && isset($existing['access_token_expires_at'])) {
+        $expires_at=(int)$existing['access_token_expires_at'];
+    }
+    if ($refresh_token==="") {
+        return false;
+    }
+    return experimentmail__oauth_tokens__save($purpose,$identity,$provider,$refresh_token,$access_token,$expires_at);
+}
+
+function experimentmail__oauth_get_valid_access_token($oauth_config,$purpose='smtp_send') {
+    $purpose=trim((string)$purpose);
+    if ($purpose==="") {
+        $purpose='smtp_send';
+    }
+    if (!is_array($oauth_config)) {
+        throw new RuntimeException("OAuth identity config is not valid.");
+    }
+    $identity=isset($oauth_config['identity']) ? strtolower(trim((string)$oauth_config['identity'])) : "";
+    $provider=isset($oauth_config['provider']) ? strtolower(trim((string)$oauth_config['provider'])) : "";
+    if ($identity==="") {
+        throw new RuntimeException("OAuth identity is missing.");
+    }
+    if ($provider==="") {
+        throw new RuntimeException("OAuth provider is missing.");
+    }
+    if (!isset($oauth_config['client_id']) || trim((string)$oauth_config['client_id'])==="") {
+        throw new RuntimeException("OAuth client id is missing.");
+    }
+    $stored=experimentmail__oauth_tokens__load($purpose,$identity,$provider);
+    $refresh_token=isset($oauth_config['refresh_token']) ? trim((string)$oauth_config['refresh_token']) : "";
+    if ($refresh_token==="") {
+        $refresh_token=($stored && isset($stored['refresh_token'])) ? trim((string)$stored['refresh_token']) : "";
+    }
+    if ($refresh_token==="") {
+        throw new RuntimeException("OAuth refresh token is missing for ".$identity.".");
+    }
+
+    if ($stored && isset($stored['access_token']) && isset($stored['access_token_expires_at'])) {
+        $stored_access=trim((string)$stored['access_token']);
+        $stored_expires=(int)$stored['access_token_expires_at'];
+        if ($stored_access!=="" && time() < ($stored_expires-60)) {
+            return $stored_access;
+        }
+    }
+
+    $json=experimentmail__oauth_refresh_access_token($oauth_config,$refresh_token);
+    $access_token=(string)$json['access_token'];
+    $expires_in=isset($json['expires_in']) ? (int)$json['expires_in'] : 3600;
+    if ($expires_in<60) {
+        $expires_in=60;
+    }
+    $expires_at=time()+$expires_in;
+    $new_refresh=$refresh_token;
+    if (isset($json['refresh_token']) && trim((string)$json['refresh_token'])!=="") {
+        $new_refresh=trim((string)$json['refresh_token']);
+    }
+    $done=experimentmail__oauth_tokens__save($purpose,$identity,$provider,$new_refresh,$access_token,$expires_at);
+    if (!$done) {
+        experimentmail__phpmailer_debug_log("oauth token storage update failed for ".$identity);
+    }
+    return $access_token;
+}
+
+function experimentmail__oauth_build_oauth64($oauth_config,$purpose='smtp_send') {
+    $identity=isset($oauth_config['identity']) ? trim((string)$oauth_config['identity']) : "";
+    if ($identity==="") {
+        throw new RuntimeException("OAuth identity is missing.");
+    }
+    $token=experimentmail__oauth_get_valid_access_token($oauth_config,$purpose);
+    $auth_string="user=".$identity."\x01auth=Bearer ".$token."\x01\x01";
+    return base64_encode($auth_string);
 }
 
 function experimentmail__split_addresses($addresses) {
@@ -97,7 +632,7 @@ function experimentmail__apply_header_addresses(&$mailer,$header_name,$header_va
 
 function experimentmail__send_via_phpmailer($recipient,$subject,$message,$headers,$env_sender="",$attachments=array()) {
     global $settings, $settings__phpmailer_host, $settings__phpmailer_port,
-        $settings__phpmailer_smtp_secure, $settings__phpmailer_smtp_auth, $settings__phpmailer_username,
+        $settings__phpmailer_smtp_secure, $settings__phpmailer_username,
         $settings__phpmailer_password, $settings__phpmailer_timeout;
 
     try {
@@ -106,7 +641,7 @@ function experimentmail__send_via_phpmailer($recipient,$subject,$message,$header
         $mailer->isSMTP();
         $mailer->Host       = (isset($settings__phpmailer_host) && $settings__phpmailer_host) ? $settings__phpmailer_host : "127.0.0.1";
         $mailer->Port       = (isset($settings__phpmailer_port) && (int)$settings__phpmailer_port > 0) ? (int)$settings__phpmailer_port : 587;
-        $mailer->SMTPAuth   = (isset($settings__phpmailer_smtp_auth) && $settings__phpmailer_smtp_auth=="y");
+        $mailer->SMTPAuth   = false;
         $mailer->Username   = (isset($settings__phpmailer_username)) ? (string)$settings__phpmailer_username : "";
         $mailer->Password   = (isset($settings__phpmailer_password)) ? (string)$settings__phpmailer_password : "";
         $mailer->SMTPSecure = (isset($settings__phpmailer_smtp_secure)) ? (string)$settings__phpmailer_smtp_secure : "";
@@ -139,6 +674,35 @@ function experimentmail__send_via_phpmailer($recipient,$subject,$message,$header
         }
         $mailer->setFrom($from_address);
         $mailer->Sender=$from_address;
+
+        $smtp_auth_type=experimentmail__phpmailer_smtp_auth_type();
+        if ($smtp_auth_type=="none") {
+            $mailer->SMTPAuth=false;
+            $mailer->Username="";
+            $mailer->Password="";
+            $mailer->AuthType="";
+        } elseif ($smtp_auth_type=="password") {
+            $mailer->SMTPAuth=true;
+            $mailer->AuthType="";
+        } elseif ($smtp_auth_type=="oauth2") {
+            $oauth_config=experimentmail__oauth_resolve_identity_config($from_address);
+            if (!is_array($oauth_config)) {
+                experimentmail__phpmailer_debug_log("oauth2 config missing for from address ".$from_address);
+                return false;
+            }
+            if (!isset($oauth_config['identity']) || !filter_var($oauth_config['identity'],FILTER_VALIDATE_EMAIL)) {
+                experimentmail__phpmailer_debug_log("oauth2 identity invalid for from address ".$from_address);
+                return false;
+            }
+            $mailer->SMTPAuth=true;
+            $mailer->AuthType='XOAUTH2';
+            $mailer->Username=$oauth_config['identity'];
+            $mailer->Password="";
+            $mailer->setOAuth(new ORSEE_PHPMailer_OAuthTokenProvider($oauth_config,'smtp_send'));
+        } else {
+            experimentmail__phpmailer_debug_log("unknown smtp auth type ".$smtp_auth_type);
+            return false;
+        }
 
         $recipient_addresses=experimentmail__split_addresses($recipient);
         foreach ($recipient_addresses as $recipient_address_line) {
@@ -1243,6 +1807,8 @@ function experimentmail__bulk_mail_form() {
     global $lang;
     //echo '<A HREF="participants_bulk_mail.php">'.lang('send_mail_to_listed_participants').'</A>';
     echo button_link("participants_bulk_mail.php",lang('send_mail_to_listed_participants'),"envelope-o");
+}
+
 }
 
 


### PR DESCRIPTION
Depends on #84 
Solving #337 #350 

- Adding OAuth authentication capability to ORSEE/PHPmailer().
- Basic flow: 1) create client ID and client secret at provider (e.g., Google Cloud, Microsoft Entra, other), 2) enter details in ORSEE's config/settings.php, 3) Authenticate with Provider in Options/Configure OAuth Tokens to obtain "refresh token" and subsequently "access tokens".
- Added documentation of outgoing email configuration (legacy or PHPmailer() with username/password or OAuth) to ORSEE Github Wiki
See: https://github.com/orsee/orsee/wiki/Installation%3A-Outgoing-email-configuration%3A-sendmail%2C-PHPmailer%2C-OAuth.
- Tested with Google Cloud but not yet with Microsoft 365 / Entra. Looking for volunteers to verify functionality and documentation. 