### PR TITLE
Bugfix: Whitelisting any $_REQUEST data before saving to database

### DIFF
--- a/admin/admin_edit.php
+++ b/admin/admin_edit.php
@@ -90,10 +90,17 @@ if ($proceed) {
             foreach (array('fname','lname') as $k) {
                 $_REQUEST[$k]=trim($_REQUEST[$k]);
             }
-            $done=orsee_db_save_array($_REQUEST,"admin",$admin_id,"admin_id");
+            $save_allowed_fields=array('fname','lname','email','language','get_calendar_mail','get_statistics_mail');
+            if (check_allow('admin_edit')) {
+                $save_allowed_fields=array_merge($save_allowed_fields,array('adminname','admin_type','experimenter_list','disabled','locked','pw_update_requested'));
+            }
+            if (isset($_REQUEST['password_crypt']) && $_REQUEST['password_crypt']) $save_allowed_fields[]='password_crypt';
+            $form_fields=array_filter_allowed($_REQUEST,$save_allowed_fields);
+            $done=orsee_db_save_array($form_fields,"admin",$admin_id,"admin_id");
             message(lang('changes_saved'));
-            log__admin("admin_edit",$_REQUEST['adminname']);
-            if ($admin_id==$expadmindata['admin_id']) $nl="&new_language=".$_REQUEST['language']; else $nl="";
+            if (isset($form_fields['adminname'])) $log_adminname=$form_fields['adminname']; else $log_adminname=$admin['adminname'];
+            log__admin("admin_edit",$log_adminname);
+            if ($admin_id==$expadmindata['admin_id']) $nl="&new_language=".$form_fields['language']; else $nl="";
             redirect ("admin/admin_edit.php?admin_id=".$admin_id.$nl);
             $proceed=false;
         }

--- a/admin/admin_type_edit.php
+++ b/admin/admin_type_edit.php
@@ -44,15 +44,17 @@ if ($proceed) {
 
         if ($continue) {
             if (!$type_id) {
-                $pars=array(':type_name'=>$type['type_name'],
-                            ':rights'=>$type['rights']);
+                $form_fields=array_filter_allowed($type,array('type_name','rights'));
+                $pars=array(':type_name'=>$form_fields['type_name'],
+                            ':rights'=>$form_fields['rights']);
                 $query="INSERT INTO ".table('admin_types')."
                     SET type_name= :type_name,
                     rights= :rights";
                 $done=or_query($query,$pars);
                 $type_id=pdo_insert_id();
             } else {
-                $done=orsee_db_save_array($type,"admin_types",$type_id,"type_id");
+                $form_fields=array_filter_allowed($type,array('rights'));
+                $done=orsee_db_save_array($form_fields,"admin_types",$type_id,"type_id");
             }
 
             if ($done) {

--- a/admin/cronjob_edit.php
+++ b/admin/cronjob_edit.php
@@ -34,10 +34,13 @@ if ($proceed) {
             $continue=false;
         }
         if ($continue) {
-            $done=orsee_db_save_array($_REQUEST,"cron_jobs",$job_name,"job_name");
-            log__admin("cronjob_edit",$_REQUEST['job_name']);
+            $form_fields=array_filter_allowed($_REQUEST,array('job_name','enabled','job_time'));
+            if (!isset($form_fields['enabled']) || $form_fields['enabled']!=='y') $form_fields['enabled']='n';
+            else $form_fields['enabled']='y';
+            $done=orsee_db_save_array($form_fields,"cron_jobs",$form_fields['job_name'],"job_name");
+            log__admin("cronjob_edit",$form_fields['job_name']);
             message (lang('changes_saved'));
-            redirect ("admin/cronjob_edit.php?job_name=".$job_name);
+            redirect ("admin/cronjob_edit.php?job_name=".$form_fields['job_name']);
             $proceed=false;
         } else {
             $job=$_REQUEST;

--- a/admin/events_edit.php
+++ b/admin/events_edit.php
@@ -36,9 +36,17 @@ if ($proceed) {
             $continue=false;
         }
 
+        if (!trim((string)$edit['reason'])) {
+            message(lang('error_event_description_required'),'error');
+            $continue=false;
+        }
+
 
         if ($continue) {
-            $done=orsee_db_save_array($edit,"events",$edit['event_id'],"event_id");
+            $form_fields=array_filter_allowed($edit,array(
+                    'event_id','laboratory_id','event_category','event_start','event_stop',
+                    'experimenter','reason','reason_public','number_of_participants'));
+            $done=orsee_db_save_array($form_fields,"events",$form_fields['event_id'],"event_id");
             if ($done) {
                 log__admin("events_edit","event_id:".$event_id);
                 message (lang('changes_saved'));
@@ -52,7 +60,7 @@ if ($proceed) {
 }
 
 if ($proceed) {
-    if ($event_id) {
+    if ($event_id && !isset($edit['event_id'])) {
         $edit=orsee_db_load_array("events",$event_id,"event_id");
         if (!isset($edit['event_id'])) redirect('admin/calendar_main.php');
     }

--- a/admin/experiment_customize_enrol_conf.php
+++ b/admin/experiment_customize_enrol_conf.php
@@ -58,8 +58,12 @@ if ($proceed) {
         }
 
         // is unknown or known?
-        if (!$id) $done=lang__insert_to_lang($sitem);
-        else $done=orsee_db_save_array($sitem,"lang",$id,"lang_id");
+        $allowed_fields=array('content_type','content_name');
+        foreach ($installed_langs as $inst_lang) $allowed_fields[]=$inst_lang;
+        $form_fields=array_filter_allowed($sitem,$allowed_fields);
+
+        if (!$id) $done=lang__insert_to_lang($form_fields);
+        else $done=orsee_db_save_array($form_fields,"lang",$id,"lang_id");
 
         if ($done) message(lang('mail_text_saved'));
         else message (lang('database_error'),'error');

--- a/admin/experiment_customize_reminder.php
+++ b/admin/experiment_customize_reminder.php
@@ -56,8 +56,12 @@ if ($proceed) {
         }
 
         // is unknown or known?
-        if (!$id) $done=lang__insert_to_lang($sitem);
-        else $done=orsee_db_save_array($sitem,"lang",$id,"lang_id");
+        $allowed_fields=array('content_type','content_name');
+        foreach ($installed_langs as $inst_lang) $allowed_fields[]=$inst_lang;
+        $form_fields=array_filter_allowed($sitem,$allowed_fields);
+
+        if (!$id) $done=lang__insert_to_lang($form_fields);
+        else $done=orsee_db_save_array($form_fields,"lang",$id,"lang_id");
 
         if ($done) message(lang('mail_text_saved'));
         else message (lang('database_error'),'error');

--- a/admin/experiment_edit.php
+++ b/admin/experiment_edit.php
@@ -93,8 +93,32 @@ if ($proceed) {
             $_REQUEST['experiment_ext_type']=trim($exptypes[1]);
 
             $edit=$_REQUEST;
+            $save_allowed_fields=array(
+                    'experiment_id','experiment_name','experiment_public_name',
+                    'experiment_description','experiment_link_to_paper',
+                    'experiment_class','experimenter','experimenter_mail',
+                    'experiment_type','experiment_ext_type','experiment_finished',
+                    'hide_in_stats','hide_in_cal','access_restricted',
+                    'payment_types','payment_budgets');
+            if (or_setting('allow_public_experiment_note') &&
+                    check_allow('experiment_edit_add_public_experiment_note')) {
+                $save_allowed_fields[]='public_experiment_note';
+            }
+            if ($settings['enable_editing_of_experiment_sender_email']=='y' &&
+                    check_allow('experiment_change_sender_address')) {
+                $save_allowed_fields[]='sender_mail';
+            }
+            if ($settings['enable_ethics_approval_module']=='y' &&
+                    check_allow('experiment_edit_ethics_approval_details')) {
+                $save_allowed_fields[]='ethics_by';
+                $save_allowed_fields[]='ethics_number';
+                $save_allowed_fields[]='ethics_exempt';
+                $save_allowed_fields[]='ethics_expire_date';
+            }
+            $form_fields=array_filter_allowed($edit,$save_allowed_fields);
 
-            $done=orsee_db_save_array($edit,"experiments",$edit['experiment_id'],"experiment_id");
+            $done=orsee_db_save_array($form_fields,"experiments",
+                    $form_fields['experiment_id'],"experiment_id");
 
             if ($done) {
                 message (lang('changes_saved'));
@@ -187,7 +211,7 @@ if ($proceed) {
                         </div>
                     </div>';
 
-    if (or_setting('allow_public_experiment_note') && check_allow('session_edit_add_public_session_note')) {
+    if (or_setting('allow_public_experiment_note') && check_allow('experiment_edit_add_public_experiment_note')) {
         echo '      <div class="field">
                         <label class="label" for="public_experiment_note">'.lang('public_experiment_note').':</label>
                         <p class="help">'.lang('public_experiment_note_note').'</p>

--- a/admin/experiment_mail_participants.php
+++ b/admin/experiment_mail_participants.php
@@ -55,8 +55,12 @@ if ($proceed) {
         }
 
         // is unknown or known?
-        if (!$id) $done=lang__insert_to_lang($sitem);
-        else $done=orsee_db_save_array($sitem,"lang",$id,"lang_id");
+        $allowed_fields=array('content_type','content_name');
+        foreach ($installed_langs as $inst_lang) $allowed_fields[]=$inst_lang;
+        $form_fields=array_filter_allowed($sitem,$allowed_fields);
+
+        if (!$id) $done=lang__insert_to_lang($form_fields);
+        else $done=orsee_db_save_array($form_fields,"lang",$id,"lang_id");
 
         if ($done) message (lang('changes_saved'));
         else message (lang('database_error'),'error');

--- a/admin/experiment_type_edit.php
+++ b/admin/experiment_type_edit.php
@@ -86,7 +86,10 @@ if ($proceed) {
 
             foreach ($languages as $language) $lsub[$language]=$selfdesc[$language];
 
-            $done=orsee_db_save_array($exptype,"experiment_types",$exptype_id,"exptype_id");
+            $form_fields=array_filter_allowed($exptype,array(
+                    'exptype_id','exptype_name','exptype_description','exptype_mapping'));
+            $form_fields['exptype_id']=$exptype_id;
+            $done=orsee_db_save_array($form_fields,"experiment_types",$exptype_id,"exptype_id");
 
             if ($new_entry) $done=lang__insert_to_lang($lsub);
             else $done=orsee_db_save_array($lsub,"lang",$lsub['lang_id'],"lang_id");

--- a/admin/lang_item_edit.php
+++ b/admin/lang_item_edit.php
@@ -164,8 +164,12 @@ if ($proceed) {
                 }
             }
 
-            if ($new) { $id=lang__insert_to_lang($sitem); $done=(bool)$id; }
-            else $done=orsee_db_save_array($sitem,"lang",$id,"lang_id");
+            $allowed_fields=array('content_type','content_name');
+            foreach ($languages as $language) $allowed_fields[]=$language;
+            $form_fields=array_filter_allowed($sitem,$allowed_fields);
+
+            if ($new) { $id=lang__insert_to_lang($form_fields); $done=(bool)$id; }
+            else $done=orsee_db_save_array($form_fields,"lang",$id,"lang_id");
 
             if (!$new && $new_id=="time") $sitem['content_name']=trim($_REQUEST['content_shortcut']);
 

--- a/admin/lang_symbol_edit.php
+++ b/admin/lang_symbol_edit.php
@@ -6,7 +6,6 @@ $menu__area="options";
 $title="edit_symbol";
 include ("header.php");
 if ($proceed) {
-
     if (isset($_REQUEST['lang_id']) && $_REQUEST['lang_id']) $lang_id=$_REQUEST['lang_id']; else $lang_id="";
 
     if ($lang_id) $allow=check_allow('lang_symbol_edit','lang_main.php');
@@ -14,8 +13,6 @@ if ($proceed) {
 }
 
 if ($proceed) {
-    $languages=get_languages();
-
     if (isset($_REQUEST['save']) && $_REQUEST['save']) {
         if (!csrf__validate_request_message()) {
             $proceed=false;
@@ -26,30 +23,46 @@ if ($proceed) {
 if ($proceed) {
     $languages=get_languages();
 
-    if (isset($_REQUEST['save']) && $_REQUEST['save']) {
-
-        $continue=true;
-        $_REQUEST['content_type']="lang";
-
-        if ($lang_id) {
-            $done=orsee_db_save_array($_REQUEST,"lang",$lang_id,"lang_id");
-        } else {
-            $lang_id=lang__insert_to_lang($_REQUEST);
-        }
-        message(lang('changes_saved'));
-
-        log__admin("language_symbol_edit","lang_id:lang,".$_REQUEST['content_name']);
-        redirect ("admin/lang_symbol_edit.php?lang_id=".$lang_id);
-    }
-}
-
-if ($proceed) {
-    // if lang id given, load data
     if ($lang_id) $content=orsee_db_load_array("lang",$lang_id,"lang_id"); else $content=array('content_name'=>'');
     if ($lang_id && (!isset($content['lang_id']))) redirect ("admin/lang_main.php");
-}
 
-if ($proceed) {
+    if (isset($_REQUEST['save']) && $_REQUEST['save']) {
+        $continue=true;
+        $can_edit_content_name=(!$lang_id || check_allow('lang_symbol_add'));
+
+        if ($can_edit_content_name) {
+            if (!isset($_REQUEST['content_name']) || trim((string)$_REQUEST['content_name'])==='') {
+                message(lang('error_lang_symbol_name_required'),'error');
+                $continue=false;
+            } else {
+                $_REQUEST['content_name']=trim((string)$_REQUEST['content_name']);
+            }
+        }
+
+        if ($continue) {
+            $_REQUEST['content_type']="lang";
+            $allowed_fields=array('content_type');
+            if ($can_edit_content_name) $allowed_fields[]='content_name';
+            foreach ($languages as $language) $allowed_fields[]=$language;
+            $form_fields=array_filter_allowed($_REQUEST,$allowed_fields);
+
+            if ($lang_id) {
+                $done=orsee_db_save_array($form_fields,"lang",$lang_id,"lang_id");
+            } else {
+                $lang_id=lang__insert_to_lang($form_fields);
+            }
+            message(lang('changes_saved'));
+
+            if (!$can_edit_content_name) $form_fields['content_name']=$content['content_name'];
+            log__admin("language_symbol_edit","lang_id:lang,".$form_fields['content_name']);
+            redirect ("admin/lang_symbol_edit.php?lang_id=".$lang_id);
+        } else {
+            $content=$_REQUEST;
+        }
+    }
+
+    show_message();
+
     echo '<div class="orsee-panel">
             <div class="orsee-panel-title"><div>'.lang('edit_symbol');
     if ($lang_id) echo ' '.$content['content_name'];

--- a/admin/participant_status_edit.php
+++ b/admin/participant_status_edit.php
@@ -120,7 +120,11 @@ if ($proceed) {
                             WHERE status_id!= :status_id";
                     $done=or_query($query,$pars);
                 }
-                $done=orsee_db_save_array($status,"participant_statuses",$status_id,"status_id");
+                $form_fields=array_filter_allowed($status,array(
+                        'status_id','access_to_profile','eligible_for_experiments',
+                        'is_default_active','is_default_inactive'));
+                $form_fields['status_id']=$status_id;
+                $done=orsee_db_save_array($form_fields,"participant_statuses",$status_id,"status_id");
             }
             message (lang('changes_saved'));
             log__admin("participant_status_edit","status_id:".$status['status_id']);

--- a/admin/participants_edit.php
+++ b/admin/participants_edit.php
@@ -26,11 +26,15 @@ if ($proceed) {
     $statuses=participant_status__get_statuses();
     $continue=true; $errors__dataform=array();
     $submit_action='';
+    $register_session=false;
+    $register_session_id=0;
     if (isset($_REQUEST['save_participant_part']) && $_REQUEST['save_participant_part']) $submit_action='public_part';
     elseif (isset($_REQUEST['save_admin_part']) && $_REQUEST['save_admin_part']) $submit_action='admin_part';
     elseif (isset($_REQUEST['add']) && $_REQUEST['add']) $submit_action='all';
 
     if ($submit_action!=='') {
+        $register_session=(isset($_REQUEST['register_session']) && $_REQUEST['register_session']=='y');
+        $register_session_id=(isset($_REQUEST['session_id']) ? (int)$_REQUEST['session_id'] : 0);
         if (!csrf__validate_request_message()) {
             $proceed=false;
         }
@@ -51,31 +55,44 @@ if ($proceed) {
         if (isset($_POST['subpool_id'])) {
             $participant['subpool_id']=$_POST['subpool_id'];
         }
+        $allowed_fields=array();
         if ($submit_action==='public_part') {
-            $errors__dataform=participantform__check_fields($participant,'profile_form_public_admin_edit');
+            $check_result=participantform__check_fields($participant,'profile_form_public_admin_edit');
+            $participant=$check_result['sanitized'];
+            $errors__dataform=$check_result['errors'];
+            $allowed_fields=$check_result['allowed_fields'];
         } elseif ($submit_action==='admin_part') {
-            $errors__dataform=participantform__check_fields($participant,'profile_form_admin_part');
+            $check_result=participantform__check_fields($participant,'profile_form_admin_part');
+            $participant=$check_result['sanitized'];
+            $errors__dataform=$check_result['errors'];
+            $allowed_fields=$check_result['allowed_fields'];
         } else {
-            $errors_public=participantform__check_fields($participant,'profile_form_public_admin_edit');
-            $errors_admin=participantform__check_fields($participant,'profile_form_admin_part');
+            $check_result_public=participantform__check_fields($participant,'profile_form_public_admin_edit');
+            $participant_public=$check_result_public['sanitized'];
+            $errors_public=$check_result_public['errors'];
+            $check_result_admin=participantform__check_fields($participant_public,'profile_form_admin_part');
+            $participant_admin=$check_result_admin['sanitized'];
+            $participant=array_merge($participant_public,$participant_admin);
+            $errors_admin=$check_result_admin['errors'];
             $errors__dataform=array_values(array_unique(array_merge($errors_public,$errors_admin)));
+            $allowed_fields=array_values(array_unique(array_merge($check_result_public['allowed_fields'],$check_result_admin['allowed_fields'])));
         }
-        $_REQUEST=$participant;
+        $form_input=$participant;
         $error_count=count($errors__dataform);
         if ($error_count>0) $continue=false;
 
         if ($continue) {
             $participant_to_save=array();
             if (!$participant_id) {
-                $new_id=participant__create_participant_id($participant);
-                $participant['participant_id']=$new_id['participant_id'];
-                $participant['participant_id_crypt']=$new_id['participant_id_crypt'];
-                $participant['creation_time']=time();
-                if (!isset($participant['subpool_id']) || !$participant['subpool_id']) {
-                    $participant['subpool_id']=$settings['subpool_default_registration_id'];
+                $new_id=participant__create_participant_id($form_input);
+                $form_input['participant_id']=$new_id['participant_id'];
+                $form_input['participant_id_crypt']=$new_id['participant_id_crypt'];
+                $form_input['creation_time']=time();
+                if (!isset($form_input['subpool_id']) || !$form_input['subpool_id']) {
+                    $form_input['subpool_id']=$settings['subpool_default_registration_id'];
                 }
-                if (!isset($participant['language']) || !$participant['language']) $participant['language']=$settings['public_standard_language'];
-                $participant_to_save=$participant;
+                if (!isset($form_input['language']) || !$form_input['language']) $form_input['language']=$settings['public_standard_language'];
+                $participant_to_save=$form_input;
             } else {
                 $participant_to_save=array('participant_id'=>$participant_id);
                 $formfields=participantform__load();
@@ -88,34 +105,34 @@ if ($proceed) {
                     $save_scope_contexts[]='profile_form_public_admin_edit';
                     $save_scope_contexts[]='profile_form_admin_part';
                 }
-                $save_subpool_id=(isset($participant['subpool_id']) ? (int)$participant['subpool_id'] : 0);
+                $save_subpool_id=(isset($form_input['subpool_id']) ? (int)$form_input['subpool_id'] : 0);
                 if ($save_subpool_id<1) $save_subpool_id=(int)$settings['subpool_default_registration_id'];
                 foreach ($formfields as $f) {
                     if (!isset($f['mysql_column_name'])) continue;
                     $field_name=(string)$f['mysql_column_name'];
                     if ($field_name==='') continue;
                     $save_field=participant__profile_field_is_applicable($f,$save_subpool_id,$save_scope_contexts);
-                    if ($save_field && array_key_exists($field_name,$participant)) {
-                        $participant_to_save[$field_name]=$participant[$field_name];
+                    if ($save_field && array_key_exists($field_name,$form_input)) {
+                        $participant_to_save[$field_name]=$form_input[$field_name];
                     }
                 }
                 if ($submit_action==='public_part') {
-                    if (array_key_exists('language',$participant)) $participant_to_save['language']=$participant['language'];
-                    if (array_key_exists('subscriptions',$participant)) $participant_to_save['subscriptions']=$participant['subscriptions'];
+                    if (array_key_exists('language',$form_input)) $participant_to_save['language']=$form_input['language'];
+                    if (array_key_exists('subscriptions',$form_input)) $participant_to_save['subscriptions']=$form_input['subscriptions'];
                 } elseif ($submit_action==='admin_part') {
                     foreach (array('subpool_id','status_id','rules_signed','remarks') as $field_name) {
-                        if (array_key_exists($field_name,$participant)) $participant_to_save[$field_name]=$participant[$field_name];
+                        if (array_key_exists($field_name,$form_input)) $participant_to_save[$field_name]=$form_input[$field_name];
                     }
                 } else {
                     foreach (array('subpool_id','status_id','rules_signed','remarks','language','subscriptions') as $field_name) {
-                        if (array_key_exists($field_name,$participant)) $participant_to_save[$field_name]=$participant[$field_name];
+                        if (array_key_exists($field_name,$form_input)) $participant_to_save[$field_name]=$form_input[$field_name];
                     }
                 }
             }
 
             if (($submit_action==='admin_part' || $submit_action==='all') && isset($participant_to_save['status_id'])) {
                 if (isset($participant_to_save['status_id'])) $sid=$participant_to_save['status_id']; else $sid='';
-                if (isset($participant['old_status_id'])) $osid=$participant['old_status_id']; else $osid='';
+                if (isset($form_input['old_status_id'])) $osid=$form_input['old_status_id']; else $osid='';
                 if ($sid!='' && $osid!='' && $osid!=$sid) {
                     $sid_e=$statuses[$sid]['eligible_for_experiments'];
                     $osid_e=$statuses[$osid]['eligible_for_experiments'];
@@ -124,7 +141,21 @@ if ($proceed) {
                 }
             }
 
-            $done=orsee_db_save_array($participant_to_save,"participants",$participant['participant_id'],"participant_id");
+            $save_allowed_fields=$allowed_fields;
+            if ($submit_action==='public_part') {
+                $save_allowed_fields=array_merge($save_allowed_fields,array('participant_id','subpool_id','language','subscriptions'));
+            } elseif ($submit_action==='admin_part') {
+                $save_allowed_fields=array_merge($save_allowed_fields,array('participant_id','subpool_id','status_id','rules_signed','remarks','deletion_time'));
+            } else {
+                $save_allowed_fields=array_merge($save_allowed_fields,array('participant_id','subpool_id','language','subscriptions','status_id','rules_signed','remarks','deletion_time'));
+            }
+            if (!$participant_id) {
+                $save_allowed_fields=array_merge($save_allowed_fields,array('participant_id_crypt','creation_time'));
+            }
+            $save_allowed_fields=array_values(array_unique($save_allowed_fields));
+            $participant_to_save=array_filter_allowed($participant_to_save,$save_allowed_fields);
+
+            $done=orsee_db_save_array($participant_to_save,"participants",$form_input['participant_id'],"participant_id");
             if ($done) {
                 if ($submit_action==='public_part') {
                     message(lang('participant_data_saved'));
@@ -135,10 +166,10 @@ if ($proceed) {
                 }
             }
 
-            if (($submit_action==='admin_part' || $submit_action==='all') && isset($_REQUEST['register_session']) && $_REQUEST['register_session']=='y') {
-                $session=orsee_db_load_array("sessions",$_REQUEST['session_id'],"session_id");
+            if (($submit_action==='admin_part' || $submit_action==='all') && $register_session) {
+                $session=orsee_db_load_array("sessions",$register_session_id,"session_id");
                 if ($session['session_id']) {
-                    $pars=array(':participant_id'=>$participant['participant_id'],
+                    $pars=array(':participant_id'=>$form_input['participant_id'],
                                 ':experiment_id'=>$session['experiment_id']);
                     $query="SELECT * FROM ".table('participate_at')."
                             WHERE participant_id= :participant_id
@@ -152,7 +183,7 @@ if ($proceed) {
                             $osession['experiment_id'].'&session_id='.$osession['session_id'].'">'.
                             session__build_name($osession).'</A>.','warning');
                         } else {
-                            $pars=array(':participant_id'=>$participant['participant_id'],
+                            $pars=array(':participant_id'=>$form_input['participant_id'],
                                         ':session_id'=>$session['session_id'],
                                         ':experiment_id'=>$session['experiment_id']);
                             $query="UPDATE ".table('participate_at')."
@@ -163,7 +194,7 @@ if ($proceed) {
                             $done2=or_query($query,$pars);
                         }
                     } else {
-                        $pars=array(':participant_id'=>$participant['participant_id'],
+                        $pars=array(':participant_id'=>$form_input['participant_id'],
                                     ':session_id'=>$session['session_id'],
                                     ':experiment_id'=>$session['experiment_id']);
                         $query="INSERT into ".table('participate_at')."
@@ -185,15 +216,15 @@ if ($proceed) {
             }
 
             if ($done) {
-                if (isset($_REQUEST['participant_id']) && $_REQUEST['participant_id'])
-                    log__admin("participant_edit","participant_id:".$participant['participant_id']);
-                else log__admin("participant_create","participant_id:".$participant['participant_id']);
+                if ($participant_id)
+                    log__admin("participant_edit","participant_id:".$form_input['participant_id']);
+                else log__admin("participant_create","participant_id:".$form_input['participant_id']);
                 $form=false;
                 $addition = "";
                 if($hide_header){
                     $addition .= "&hide_header=true";
                 }
-                redirect ("admin/participants_edit.php?participant_id=".$participant['participant_id'].$addition);
+                redirect ("admin/participants_edit.php?participant_id=".$form_input['participant_id'].$addition);
             } else {
                 message(lang('database_error'),'error');
             }
@@ -204,25 +235,27 @@ if ($proceed) {
 if ($proceed) {
 
     if ($participant_id && $continue) {
-        $_REQUEST=orsee_db_load_array("participants",$participant_id,"participant_id");
+        $form_input=orsee_db_load_array("participants",$participant_id,"participant_id");
+    } elseif (!isset($form_input) || !is_array($form_input)) {
+        $form_input=array();
     }
 
     $button_title = ($participant_id) ? lang('save') : lang('add');
 
     show_message();
     if (!$hide_header) echo '<div class="orsee-panel">';
-    participant__show_admin_form($_REQUEST,$button_title,$errors__dataform,true);
+    participant__show_admin_form($form_input,$button_title,$errors__dataform,true);
     if (!$hide_header) echo '</div>';
     if ($participant_id) participants__get_statistics($participant_id);
 
-    if ($settings['enable_email_module']=='y' && isset($_REQUEST['participant_id'])) {
-        $nums=email__get_privileges('participant',$_REQUEST,'read',true);
+    if ($settings['enable_email_module']=='y' && isset($form_input['participant_id'])) {
+        $nums=email__get_privileges('participant',$form_input,'read',true);
         if ($nums['allowed'] && $nums['num_all']>0) {
             echo '<div class="orsee-panel-title" style="margin-top: 1rem;"><div class="orsee-panel-title-main">'.lang('emails').'</div></div>';
             echo javascript__email_popup();
             $url_string='participant_id='.$participant_id;
             if ($hide_header) $url_string.='&hide_header=true';
-            email__list_emails('participant',$_REQUEST['participant_id'],$nums['rmode'],$url_string,false);
+            email__list_emails('participant',$form_input['participant_id'],$nums['rmode'],$url_string,false);
         }
     }
 

--- a/admin/participation_status_edit.php
+++ b/admin/participation_status_edit.php
@@ -100,7 +100,10 @@ if ($proceed) {
             if ($not_assigned) {
                 $pstatus=$_REQUEST;
                 $pstatus['pstatus_id']=$pstatus_id;
-                $done=orsee_db_save_array($pstatus,"participation_statuses",$pstatus_id,"pstatus_id");
+                $form_fields=array_filter_allowed($pstatus,array(
+                        'pstatus_id','participated','noshow','participateagain'));
+                $form_fields['pstatus_id']=$pstatus_id;
+                $done=orsee_db_save_array($form_fields,"participation_statuses",$pstatus_id,"pstatus_id");
             }
             message (lang('changes_saved'));
             log__admin("participation_status_edit","pstatus_id:".$pstatus['pstatus_id']);

--- a/admin/payments_budget_edit.php
+++ b/admin/payments_budget_edit.php
@@ -51,8 +51,11 @@ if ($proceed) {
 
             $budget=$_REQUEST;
             $budget['budget_id']=$budget_id;
-            if (!$budget['budget_limit']) $budget['budget_limit']=NULL;
-            $done=orsee_db_save_array($budget,"budgets",$budget_id,"budget_id");
+            $form_fields=array_filter_allowed($budget,array(
+                    'budget_id','budget_name','budget_limit','experimenter','enabled'));
+            $form_fields['budget_id']=$budget_id;
+            if (!$form_fields['budget_limit']) $form_fields['budget_limit']=NULL;
+            $done=orsee_db_save_array($form_fields,"budgets",$budget_id,"budget_id");
 
             message (lang('changes_saved'));
             log__admin("payments_budget_edit","budget_id:".$budget['budget_id']);

--- a/admin/session_edit.php
+++ b/admin/session_edit.php
@@ -81,17 +81,29 @@ if ($proceed) {
         }
 
         $edit=$_REQUEST;
+        $save_allowed_fields=array(
+            'session_id','experiment_id','laboratory_id','session_start',
+            'session_duration_hour','session_duration_minute',
+            'part_needed','part_reserve',
+            'registration_end_hours','session_reminder_hours','send_reminder_on',
+            'session_remarks','session_status','reg_notice_sent',
+            'payment_types','payment_budgets'
+        );
+        if (or_setting('allow_public_session_note') && check_allow('session_edit_add_public_session_note')) {
+            $save_allowed_fields[]='public_session_note';
+        }
+        $form_fields=array_filter_allowed($edit,$save_allowed_fields);
 
-        $done=orsee_db_save_array($edit,"sessions",$edit['session_id'],"session_id");
+        $done=orsee_db_save_array($form_fields,"sessions",$form_fields['session_id'],"session_id");
 
         if ($done) {
-            log__admin("session_edit","session:".session__build_name($edit,
-                    $settings['admin_standard_language']).", session_id:".$edit['session_id'].", experiment_id:".$edit['experiment_id']);
+            log__admin("session_edit","session:".session__build_name($form_fields,
+                    $settings['admin_standard_language']).", session_id:".$form_fields['session_id'].", experiment_id:".$form_fields['experiment_id']);
             message (lang('changes_saved'));
-            redirect ('admin/session_edit.php?session_id='.$edit['session_id']);
+            redirect ('admin/session_edit.php?session_id='.$form_fields['session_id']);
         } else {
             lang('database_error');
-            redirect ('admin/session_edit.php?session_id='.$edit['session_id']);
+            redirect ('admin/session_edit.php?session_id='.$form_fields['session_id']);
         }
     }
 }

--- a/admin/subpool_edit.php
+++ b/admin/subpool_edit.php
@@ -94,7 +94,11 @@ if ($proceed) {
             $subpool=$_REQUEST;
             $subpool['experiment_types']=id_array_to_db_string($exptype_ids);
             foreach ($languages as $language) $lsub[$language]=$selfdesc[$language];
-            $done=orsee_db_save_array($subpool,"subpools",$subpool_id,"subpool_id");
+            $form_fields=array_filter_allowed($subpool,array(
+                    'subpool_id','subpool_name','subpool_description',
+                    'experiment_types','show_at_registration_page'));
+            $form_fields['subpool_id']=$subpool_id;
+            $done=orsee_db_save_array($form_fields,"subpools",$subpool_id,"subpool_id");
             if ($new) $lsub['lang_id']=lang__insert_to_lang($lsub);
             else $done=orsee_db_save_array($lsub,"lang",$lsub['lang_id'],"lang_id");
 

--- a/config/dbupdates.php
+++ b/config/dbupdates.php
@@ -2231,4 +2231,24 @@ $system__database_upgrades[]=array(
     )
 );
 
+$system__database_upgrades[]=array(
+'version'=>'2026042601',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'error_lang_symbol_name_required',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'Symbol name is required','de'=>'Symbolname muss angegeben werden.')
+    )
+);
+
+$system__database_upgrades[]=array(
+'version'=>'2026042602',
+'type'=>'new_lang_item',
+'specs'=> array(
+    'content_name'=>'error_event_description_required',
+    'content_type'=>'lang',
+    'content'=>array('en'=>'An (internal) event description is required.','de'=>'Eine (interne) Event-Beschreibung muss angegeben werden.')
+    )
+);
+
 ?>

--- a/config/system.php
+++ b/config/system.php
@@ -2,7 +2,7 @@
 // part of orsee. see orsee.org
 // THIS FILE WILL CHANGE FROM VERSION TO VERSION. BETTER NOT EDIT.
 $system__version="3.3.0";
-$system__database_version=2026042505;
+$system__database_version=2026042602;
 
 // implemented experiment types
 $system__experiment_types=array('laboratory','online-survey','internet');

--- a/public/participant_create.php
+++ b/public/participant_create.php
@@ -115,11 +115,14 @@ if ($proceed) {
                 if (!is_array($v)) $_REQUEST[$k]=trim($v);
             }
             $_REQUEST['subpool_id']=$selected_subpool;
-            $errors__dataform=participantform__check_fields($_REQUEST,'profile_form_public_create');
+            $check_result=participantform__check_fields($_REQUEST,'profile_form_public_create');
+            $errors__dataform=$check_result['errors'];
+            $form_input=$check_result['sanitized'];
+            $allowed_fields=$check_result['allowed_fields'];
             $error_count=count($errors__dataform);
             if ($error_count>0) $continue=false;
 
-            $response=participantform__check_unique($_REQUEST,"create");
+            $response=participantform__check_unique($form_input,"create");
             if (isset($response['disable_form']) && $response['disable_form']) {
                 $continue=false;
                 $proceed=false;
@@ -137,12 +140,12 @@ if ($proceed) {
             if ($settings['subject_authentication']!='token') {
                 if (isset($_SESSION['pauthdata']['pw_provided']) && $_SESSION['pauthdata']['pw_provided'] &&
                     isset($_SESSION['pauthdata']['submitted_checked_pw']) && $_SESSION['pauthdata']['submitted_checked_pw']) {
-                    $_REQUEST['password']=$_SESSION['pauthdata']['submitted_checked_pw'];
+                    $form_input['password']=$_SESSION['pauthdata']['submitted_checked_pw'];
                 } else {
-                    $pw_ok=participant__check_password($_REQUEST['password'],$_REQUEST['password2']);
+                    $pw_ok=participant__check_password($form_input['password'],$form_input['password2']);
                     if ($pw_ok) {
                         $_SESSION['pauthdata']['pw_provided']=true;
-                        $_SESSION['pauthdata']['submitted_checked_pw']=$_REQUEST['password'];
+                        $_SESSION['pauthdata']['submitted_checked_pw']=$form_input['password'];
                     } else {
                         $continue=false;
                     }
@@ -151,7 +154,7 @@ if ($proceed) {
         }
 
         if ($continue) {
-            $participant=$_REQUEST;
+            $participant=$form_input;
             unset ($_SESSION['pauthdata']['pw_provided']);
             unset ($_SESSION['pauthdata']['submitted_checked_pw']);
             unset ($_SESSION['captcha_string']);
@@ -167,6 +170,11 @@ if ($proceed) {
             $participant['status_id']=0;
             $participant['subpool_id']=$selected_subpool;
             if (!isset($participant['language']) || !$participant['language']) $participant['language']=$settings['public_standard_language'];
+            $save_allowed_fields=array_values(array_unique(array_merge(
+                $allowed_fields,
+                array('language','participant_id','participant_id_crypt','password_crypted','confirmation_token','creation_time','last_profile_update','status_id','subpool_id')
+            )));
+            $participant=array_filter_allowed($participant,$save_allowed_fields);
             $done=orsee_db_save_array($participant,"participants",$participant['participant_id'],"participant_id");
             if ($done) {
                 log__participant("subscribe",$participant['lname'].', '.$participant['fname']);
@@ -195,7 +203,12 @@ if ($proceed) {
             if (count($all_pool_ids)>0) $render_subpool=(int)$all_pool_ids[0];
             else $render_subpool=1;
         }
-        $_REQUEST['subpool_id']=$render_subpool;
+        $render_input=array();
+        if (isset($_REQUEST['add']) && $_REQUEST['add']) {
+            if (isset($form_input) && is_array($form_input)) $render_input=$form_input;
+            else $render_input=$_REQUEST;
+        }
+        $render_input['subpool_id']=$render_subpool;
 
         $pw_provided=(isset($_SESSION['pauthdata']['pw_provided']) && $_SESSION['pauthdata']['pw_provided']);
         $force_form_stage=(isset($_REQUEST['add']) && $_REQUEST['add']);
@@ -262,7 +275,7 @@ if ($proceed) {
                                 <input type="hidden" name="subpool_id" id="orsee-public-create-subpool-input" value="'.htmlspecialchars((string)$selected_subpool,ENT_QUOTES,'UTF-8').'">
                                 <input type="hidden" name="accept_rules" id="orsee-public-create-rules-input" value="'.htmlspecialchars((string)$rules_accepted,ENT_QUOTES,'UTF-8').'">
                                 <div class="orsee-form-shell orsee-public-profile-shell">';
-        participant__show_inner_form($_REQUEST,$errors__dataform,'profile_form_public_create');
+        participant__show_inner_form($render_input,$errors__dataform,'profile_form_public_create');
 
         if ($settings['subject_authentication']!='token') {
             if ($pw_provided) {

--- a/public/participant_edit.php
+++ b/public/participant_edit.php
@@ -37,22 +37,30 @@ if ($proceed) {
         foreach ($_REQUEST as $k=>$v) {
             if(!is_array($v)) $_REQUEST[$k]=trim($v);
         }
-        $errors__dataform=participantform__check_fields($_REQUEST,'profile_form_public_edit');
+        $check_result=participantform__check_fields($_REQUEST,'profile_form_public_edit');
+        $errors__dataform=$check_result['errors'];
+        $form_input=$check_result['sanitized'];
+        $allowed_fields=$check_result['allowed_fields'];
         $error_count=count($errors__dataform);
         if ($error_count>0) $continue=false;
 
-        $response=participantform__check_unique($_REQUEST,"edit",$_REQUEST['participant_id']);
+        $response=participantform__check_unique($form_input,"edit",$form_input['participant_id']);
         if($response['problem']) { $continue=false; }
 
         if ($continue) {
             if (isset($participant['pending_profile_update_request']) && $participant['pending_profile_update_request']=='y') {
-                $_REQUEST['pending_profile_update_request']='n';
-                $_REQUEST['profile_update_request_new_pool']=NULL;
+                $form_input['pending_profile_update_request']='n';
+                $form_input['profile_update_request_new_pool']=NULL;
                 message(lang('profile_confirmed').'<BR>');
             }
-            $participant=$_REQUEST;
+            $participant=$form_input;
 
             $participant['last_profile_update']=time();
+            $save_allowed_fields=array_values(array_unique(array_merge(
+                $allowed_fields,
+                array('participant_id','subpool_id','language','pending_profile_update_request','profile_update_request_new_pool','last_profile_update')
+            )));
+            $participant=array_filter_allowed($participant,$save_allowed_fields);
 
             $done=orsee_db_save_array($participant,"participants",$participant['participant_id'],"participant_id");
 
@@ -69,7 +77,7 @@ if ($proceed) {
     if ((!isset($_REQUEST['add']) || !$_REQUEST['add']) &&
         (!isset($_REQUEST['submit']) || !$_REQUEST['submit']) &&
         !(isset($_REQUEST['doit']) && $_REQUEST['doit'])) {
-        $_REQUEST=$participant;
+        $form_input=$participant;
     }
 }
 
@@ -77,7 +85,7 @@ if ($proceed) {
     if (isset($participant['pending_profile_update_request']) && $participant['pending_profile_update_request']=='y') {
         message(lang('profile_update_request_message').'<BR>','warning');
         if (isset($participant['profile_update_request_new_pool']) && $participant['profile_update_request_new_pool']) {
-            $_REQUEST['subpool_id']=$participant['profile_update_request_new_pool'];
+            $form_input['subpool_id']=$participant['profile_update_request_new_pool'];
         }
     }
 }
@@ -174,7 +182,7 @@ if ($proceed) {
                                 <form id="orsee-public-unsubscribe-form" action="'.$edit_url.'" method="POST" class="orsee-public-profile-form">
                                     '.csrf__field().'
                                     <div class="orsee-form-shell orsee-public-profile-shell">';
-        participant__show_inner_form($_REQUEST,$errors__dataform,'profile_form_public_edit');
+        participant__show_inner_form($form_input,$errors__dataform,'profile_form_public_edit');
         echo '                      <div class="orsee-public-profile-actions">
                                         <button class="button orsee-public-btn" name="add" type="submit" value="true">'.lang('save').'</button>
                                     </div>

--- a/tagsets/helpers.php
+++ b/tagsets/helpers.php
@@ -355,6 +355,12 @@ function id_array_to_db_string($id_array) {
     return $db_string;
 }
 
+function array_filter_allowed($array,$whitelist) {
+    if (!is_array($array)) return array();
+    if (!is_array($whitelist) || count($whitelist)===0) return array();
+    return array_intersect_key($array,array_flip($whitelist));
+}
+
 function db_string_to_id_array($db_string) {
     $in_array=explode(",",$db_string); $out_array=array();
     foreach ($in_array as $k=>$v) {

--- a/tagsets/participant.php
+++ b/tagsets/participant.php
@@ -358,6 +358,7 @@ function participantform__get_nonunique($edit,$participant_id=0,$scope_context='
 function participantform__check_fields(&$edit,$scope_context='') {
     global $lang, $settings;
     $errors_dataform=array();
+    $allowed_fields=array();
     $scope_context=trim((string)$scope_context);
 
     if (!isset($edit['subpool_id']) || !$edit['subpool_id']) $edit['subpool_id']=$settings['subpool_default_registration_id'];
@@ -394,6 +395,7 @@ function participantform__check_fields(&$edit,$scope_context='') {
             $check_this_field=false;
         }
         if ($check_this_field) {
+            $allowed_fields[$f['mysql_column_name']]=$f['mysql_column_name'];
             if ($f['mysql_column_name']==='email') {
                 $email_input_mode=(isset($f['email_mode']['mode']) ? trim((string)$f['email_mode']['mode']) : 'full_email');
                 $email_fixed_domain=(isset($f['email_mode']['domain']) ? strtolower(trim((string)$f['email_mode']['domain'])) : '');
@@ -508,13 +510,19 @@ function participantform__check_fields(&$edit,$scope_context='') {
         if (!isset($_REQUEST['subscriptions']) || !is_array($_REQUEST['subscriptions'])) $_REQUEST['subscriptions']=array();
         $_REQUEST['subscriptions']=id_array_to_db_string($_REQUEST['subscriptions']);
         $edit['subscriptions']=$_REQUEST['subscriptions'];
+        $allowed_fields['subscriptions']='subscriptions';
         if(!$edit['subscriptions']) {
             $errors_dataform[]='subscriptions';
             message(lang('at_least_one_exptype_has_to_be_selected'),'warning');
         }
     }
 
-    return $errors_dataform;
+    $allowed_fields=array_values($allowed_fields);
+    return array(
+        'errors'=>$errors_dataform,
+        'sanitized'=>$edit,
+        'allowed_fields'=>$allowed_fields
+    );
 }
 /*
  * Central field editor specification for options_participant_profile_edit.php.
@@ -3357,18 +3365,18 @@ function participant__show_admin_form($edit,$button_title="",$errors=array(),$ex
     echo '<div class="field orsee-status-field">';
     echo '<label class="label">'.lang('participant_status').'</label>';
     echo '<div class="control">';
+    if(!isset($edit['status_id'])) $edit['status_id']="";
     if (check_allow('participants_change_status')) {
-        if(!isset($_REQUEST['status_id'])) $_REQUEST['status_id']="";
-        if ($_REQUEST['status_id']=='0') $hide=array(); else $hide=array('0');
-        echo '<INPUT type="hidden" name="old_status_id" value="'.$_REQUEST['status_id'].'">'.
-                participant_status__select_field('status_id',$_REQUEST['status_id'],$hide);
+        if ($edit['status_id']=='0') $hide=array(); else $hide=array('0');
+        echo '<INPUT type="hidden" name="old_status_id" value="'.$edit['status_id'].'">'.
+                participant_status__select_field('status_id',$edit['status_id'],$hide);
     } elseif (!$edit['participant_id']) {
         $default_status=participant_status__get("is_default_active");
         $statuses=participant_status__get_statuses();
         echo '<INPUT type="hidden" name="status_id" value="'.$default_status.'">'.
                     $statuses[$default_status]['name'];
     } else {
-        echo participant_status__get_name($_REQUEST['status_id']);
+        echo participant_status__get_name($edit['status_id']);
     }
     echo '</div>';
     echo '</div>';


### PR DESCRIPTION
Hat tip to @mrpg for reporting the issue.

This fix makes sure that any $_REQUEST data submitted in forms in the public and admin area is filtered such that only fields that are incldued in the current form are sent to the database save function.