### PR TITLE
Bugfix fixes 2 for v3.4.0

### DIFF
--- a/admin/download_edit.php
+++ b/admin/download_edit.php
@@ -120,7 +120,7 @@ if ($proceed) {
                     <div class="field">
                         <label class="label" for="upload_name">'.lang('upload_name').':</label>
                         <div class="control">
-                            <input id="upload_name" class="input is-primary orsee-input orsee-input-text" type="text" name="upload_name" maxlength="40" value="'.$upload['upload_name'].'">
+                            <input id="upload_name" class="input is-primary orsee-input orsee-input-text" type="text" name="upload_name" maxlength="40" value="'.htmlspecialchars($upload['upload_name'],ENT_QUOTES,'UTF-8').'">
                         </div>
                     </div>
                     <div class="field orsee-form-row-grid orsee-form-row-grid--2 orsee-form-actions">

--- a/admin/download_upload.php
+++ b/admin/download_upload.php
@@ -153,7 +153,7 @@ if ($proceed) {
                     <div class="field">
                         <label class="label" for="upload_name">'.lang('upload_name').':</label>
                         <div class="control">
-                            <input id="upload_name" class="input is-primary orsee-input orsee-input-text" type="text" name="upload_name" maxlength="40" value="'.$_REQUEST['upload_name'].'">
+                            <input id="upload_name" class="input is-primary orsee-input orsee-input-text" type="text" name="upload_name" maxlength="40" value="'.htmlspecialchars($_REQUEST['upload_name'],ENT_QUOTES,'UTF-8').'">
                         </div>
                     </div>
                     <div class="field">

--- a/admin/experiment_add_participants.php
+++ b/admin/experiment_add_participants.php
@@ -89,6 +89,7 @@ if ($proceed) {
             $query_id=$_SESSION['lastqueryid_assign_'.$experiment_id];
             $posted_query=json_decode($posted_query_json,true);
             $sort=query__get_sort('assign',$_REQUEST['search_sort']);  // sanitize sort
+            $_REQUEST['search_sort']=$sort;
         } else {
             // store new query in session
             $query_id=time();
@@ -121,8 +122,8 @@ if ($proceed) {
         if ($settings['allow_permanent_queries']=='y' && check_allow('experiment_assign_query_permanent_activate')) {
             $cgivars=array();
             $cgivars[]="make_permanent=true";
-            if (isset($_REQUEST['search_sort'])) {
-                $cgivars[]='search_sort='.urlencode($_REQUEST['search_sort']);
+            if ($sort) {
+                $cgivars[]='search_sort='.urlencode($sort);
             }
             $cgivars[]='experiment_id='.$experiment_id;
             $cgivars[]='csrf_token='.urlencode(csrf__get_token());

--- a/admin/experiment_drop_participants.php
+++ b/admin/experiment_drop_participants.php
@@ -81,6 +81,7 @@ if ($proceed) {
             $query_id=$_SESSION['lastqueryid_deassign_'.$experiment_id];
             $posted_query=json_decode($posted_query_json,true);
             $sort=query__get_sort('assign',$_REQUEST['search_sort']);  // sanitize sort
+            $_REQUEST['search_sort']=$sort;
         } else {
             // store new query in session
             $query_id=time();

--- a/admin/experiment_participants_show.php
+++ b/admin/experiment_participants_show.php
@@ -33,23 +33,24 @@ if ($proceed) {
     }
 
     if (isset($_REQUEST['search_sort']) && $_REQUEST['search_sort']) {
-        $sort=$_REQUEST['search_sort'];
+        $sort=query__get_sort('session_participants_list',$_REQUEST['search_sort']);
+        $_REQUEST['search_sort']=$sort;
     } else {
         $sort='';
     }
 
-    $thiscgis='?experiment_id='.$experiment_id;
+    $thiscgis='?experiment_id='.urlencode((string)$experiment_id);
     if ($session_id) {
-        $thiscgis.='&session_id='.$session_id;
+        $thiscgis.='&session_id='.urlencode((string)$session_id);
     }
     if ($pstatus!='') {
-        $thiscgis.='&pstatus='.$pstatus;
+        $thiscgis.='&pstatus='.urlencode((string)$pstatus);
     }
     if ($focus) {
-        $thiscgis.='&focus='.$focus;
+        $thiscgis.='&focus='.urlencode($focus);
     }
     if ($sort) {
-        $thiscgis.='&search_sort='.$sort;
+        $thiscgis.='&search_sort='.urlencode($sort);
     }
 
     $allow=check_allow('experiment_show_participants','experiment_show.php?experiment_id='.$experiment_id);

--- a/admin/experiment_participants_show_csv.php
+++ b/admin/experiment_participants_show_csv.php
@@ -30,7 +30,7 @@ if ($proceed) {
     }
 
     if (isset($_REQUEST['search_sort']) && $_REQUEST['search_sort']) {
-        $sort=$_REQUEST['search_sort'];
+        $sort=query__get_sort('session_participants_list_pdf',$_REQUEST['search_sort']);
     } else {
         $sort='';
     }

--- a/admin/experiment_participants_show_pdf.php
+++ b/admin/experiment_participants_show_pdf.php
@@ -30,7 +30,7 @@ if ($proceed) {
     }
 
     if (isset($_REQUEST['search_sort']) && $_REQUEST['search_sort']) {
-        $sort=$_REQUEST['search_sort'];
+        $sort=query__get_sort('session_participants_list_pdf',$_REQUEST['search_sort']);
     } else {
         $sort='';
     }

--- a/admin/participants_show.php
+++ b/admin/participants_show.php
@@ -323,8 +323,8 @@ if ($proceed) {
         if ($search_sort) {
             echo '<input type="hidden" name="search_sort" value="'.htmlspecialchars($search_sort,ENT_QUOTES,'UTF-8').'">';
         }
-        if (isset($_REQUEST['active'])) {
-            echo '<input type="hidden" name="active" value="'.$_REQUEST['active'].'">';
+        if ($active) {
+            echo '<input type="hidden" name="active" value="true">';
         }
 
         if ($active) {

--- a/admin/participants_show.php
+++ b/admin/participants_show.php
@@ -18,6 +18,17 @@ if ($proceed) {
         $active=false;
     }
 
+    if (isset($_REQUEST['search_sort']) && $_REQUEST['search_sort']) {
+        if ($active) {
+            $search_sort=query__get_sort('participants_search_active',$_REQUEST['search_sort']);
+        } else {
+            $search_sort=query__get_sort('participants_search_all',$_REQUEST['search_sort']);
+        }
+        $_REQUEST['search_sort']=$search_sort;
+    } else {
+        $search_sort='';
+    }
+
     // to encode: json_encode($_REQUEST['form']).'<BR>';
     // do decode: json_decode($_SESSION['lastquery'],true);
 
@@ -50,8 +61,8 @@ if ($proceed) {
             $done=query__save_query($posted_query_json,'participants_search_all');
         }
         $cgivars=array();
-        if (isset($_REQUEST['search_sort'])) {
-            $cgivars[]='search_sort='.urlencode($_REQUEST['search_sort']);
+        if ($search_sort) {
+            $cgivars[]='search_sort='.urlencode($search_sort);
         }
         if ($active) {
             $cgivars[]='active=true';
@@ -75,12 +86,6 @@ if ($proceed) {
 
 if ($proceed) {
     if (isset($_REQUEST['action']) && $_REQUEST['action']) {
-        if (isset($_REQUEST['search_sort'])) {
-            $search_sort=$_REQUEST['search_sort'];
-        } else {
-            $search_sort='';
-        }
-
         $plist_ids=array();
         if (isset($_REQUEST['sel'])) {
             foreach ($_REQUEST['sel'] as $k=>$v) {
@@ -124,7 +129,7 @@ if ($proceed) {
                     $done=experimentmail__send_bulk_mail_to_queue($bulk_id,$plist_ids);
                     message($num_participants.' '.lang('xxx_bulk_mails_sent_to_mail_queue'));
                     log__admin("bulk_mail","recipients: ".$num_participants);
-                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.$search_sort);
+                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.urlencode($search_sort));
                 } else {
                     $_REQUEST['search_sort']=$search_sort;
                 }
@@ -148,7 +153,7 @@ if ($proceed) {
                             WHERE participant_id = :participant_id";
                     $done=or_query($query,$pars);
                     message($num_participants.' '.lang('xxx_participants_moved_to_new_status'));
-                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.$search_sort);
+                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.urlencode($search_sort));
                 }
             } elseif ($_REQUEST['action']=='profile_update') {
                 // new_profile_update_status do_pool_transfer new_pool
@@ -186,7 +191,7 @@ if ($proceed) {
                                 WHERE participant_id = :participant_id";
                     $done=or_query($query,$pars);
                     message($num_participants.' '.lang('xxx_participants_were_assigned_a_new_profile_update_status'));
-                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.$search_sort);
+                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.urlencode($search_sort));
                 }
             } elseif ($_REQUEST['action']=='bulk_anonymization') {
                 // do_status_change new_status
@@ -237,11 +242,11 @@ if ($proceed) {
                     $query.=" WHERE participant_id = :participant_id ";
                     $done=or_query($query,$pars);
                     message($num_participants.' '.lang('xxx_participant_profiles_were_anonymized'));
-                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.$search_sort);
+                    redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.urlencode($search_sort));
                 }
             } else {
                 // redirect to same page
-                redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.$search_sort);
+                redirect('admin/'.thisdoc().'?active='.$active.'&search_sort='.urlencode($search_sort));
             }
         } else {
             message(lang('no_participants_selected'),'warning');
@@ -259,17 +264,16 @@ if ($proceed) {
 
 if ($proceed) {
     if (isset($_REQUEST['search_submit']) || isset($_REQUEST['search_sort'])) {
-        if (isset($_REQUEST['search_sort'])) {
+        if ($search_sort) {
             // use old query
             if ($active) {
                 $posted_query_json=$_SESSION['lastquery_participants_search_active'];
                 $query_id=$_SESSION['lastqueryid_participants_search_active'];
-                $sort=query__get_sort('participants_search_active',$_REQUEST['search_sort']); // sanitize sort
             } else {
                 $posted_query_json=$_SESSION['lastquery_participants_search_all'];
                 $query_id=$_SESSION['lastqueryid_participants_search_all'];
-                $sort=query__get_sort('participants_search_all',$_REQUEST['search_sort']); // sanitize sort
             }
+            $sort=$search_sort;
             $posted_query=json_decode($posted_query_json,true);
         } else {
             // store new query in session
@@ -316,8 +320,8 @@ if ($proceed) {
 
         echo '<form id="bulkactionform" action="participants_show.php" method="POST">';
         echo csrf__field();
-        if (isset($_REQUEST['search_sort'])) {
-            echo '<input type="hidden" name="search_sort" value="'.$_REQUEST['search_sort'].'">';
+        if ($search_sort) {
+            echo '<input type="hidden" name="search_sort" value="'.htmlspecialchars($search_sort,ENT_QUOTES,'UTF-8').'">';
         }
         if (isset($_REQUEST['active'])) {
             echo '<input type="hidden" name="active" value="'.$_REQUEST['active'].'">';

--- a/tagsets/email.php
+++ b/tagsets/email.php
@@ -1521,7 +1521,7 @@ function email__is_allowed($email,$experiment,$priv='read') {
             }
         }
         if ($continue && $settings['email_module_allow_assign_emails']=='y' && check_allow('emails_'.$priv.'_assigned')) {
-            $assigned_to=db_string_to_id_array($experiment['assigned_to']);
+            $assigned_to=db_string_to_id_array($email['assigned_to']);
             if (in_array($expadmindata['admin_id'],$assigned_to)) {
                 $return=true;
                 $continue=false;

--- a/tagsets/email.php
+++ b/tagsets/email.php
@@ -1156,6 +1156,10 @@ function email__participant_select($email,$participant=array(),$guess_parts=arra
                 ORDER BY ".$sort;
         $result=or_query($query,$pars);
         while ($p=pdo_fetch_assoc($result)) {
+            if (isset($participant['participant_id'])
+                && $p['participant_id']==$participant['participant_id']) {
+                continue;
+            }
             echo '<OPTION value="'.$p['participant_id'].'">';
             $items=array();
             foreach ($cols as $k=>$c) {

--- a/tagsets/email.php
+++ b/tagsets/email.php
@@ -1146,7 +1146,7 @@ function email__participant_select($email,$participant=array(),$guess_parts=arra
             }
         }
     }
-    if (count($guess_parts)>0 && $email['session_id']) {
+    if ($email['session_id']) {
         $sort=query__load_default_sort('email_participant_guesses_list');
         $pars=array(':session_id'=>$email['session_id']);
         $query="SELECT * from ".table('participants')."

--- a/tagsets/experimentmail.php
+++ b/tagsets/experimentmail.php
@@ -1967,7 +1967,7 @@ namespace {
 
 
     function experimentmail__send_registration_notice($line) {
-        global $settings;
+        global $settings, $expadmindata;
         $reg=experiment__count_participate_at($line['experiment_id'],$line['session_id']);
         $experimenters=db_string_to_id_array($line['experimenter_mail']);
 
@@ -1991,7 +1991,11 @@ namespace {
                 $now=time();
                 $list_name=lang('participant_list_filename').' '.date("Y-m-d",$now);
                 $list_filename=str_replace(" ","_",$list_name).".pdf";
+                $old_expadmindata=(isset($expadmindata) ? $expadmindata : array());
+                $expadmindata=$admin;
+                $expadmindata['rights']=admin__load_admin_rights($expadmindata['admin_type']);
                 $list_file=pdfoutput__make_part_list($line['experiment_id'],$line['session_id'],'registered','lname,fname',true,$tlang);
+                $expadmindata=$old_expadmindata;
                 $done=experimentmail__mail_attach($recipient,$settings['support_mail'],$subject,$message,$list_filename,$list_file);
             }
         }

--- a/tagsets/query.php
+++ b/tagsets/query.php
@@ -444,16 +444,16 @@ function query__headcell($name,$sort="",$allow_sort=true) {
     if ($allow_sort && $sort) {
         $out.= '<A class="orsee-sort-link" HREF="'.thisdoc().'?search_sort='.urlencode($sort);
         if ($_REQUEST['experiment_id']) {
-            $out.= '&experiment_id='.$_REQUEST['experiment_id'];
+            $out.= '&experiment_id='.urlencode((string)$_REQUEST['experiment_id']);
         }
         if ($_REQUEST['session_id']) {
-            $out.= '&session_id='.$_REQUEST['session_id'];
+            $out.= '&session_id='.urlencode((string)$_REQUEST['session_id']);
         }
         if ($_REQUEST['focus']) {
-            $out.= '&focus='.$_REQUEST['focus'];
+            $out.= '&focus='.urlencode((string)$_REQUEST['focus']);
         }
         if ($_REQUEST['active']) {
-            $out.= '&active='.$_REQUEST['active'];
+            $out.= '&active='.urlencode((string)$_REQUEST['active']);
         }
         $out.= '">';
     }

--- a/tagsets/updownloads.php
+++ b/tagsets/updownloads.php
@@ -75,7 +75,7 @@ function downloads__list_files_general($showsize=false,$showtype=false,$showdate
                             '/'.rawurlencode($upload['upload_name'].'.'.$upload['upload_suffix']).
                             '?t=d&i='.$upload['upload_id'].'">';
                 }
-                $out.= $upload['upload_name'];
+                $out.= htmlspecialchars($upload['upload_name'],ENT_QUOTES,'UTF-8');
                 if ($allow_dl) {
                     $out.= '</A>';
                 }
@@ -84,7 +84,7 @@ function downloads__list_files_general($showsize=false,$showtype=false,$showdate
                     $out.= '<div class="orsee-table-cell" data-label="'.lang('size').'">'.number_format(round($upload['upload_filesize']/1024),0).' KB</div>';
                 }
                 if ($showtype) {
-                    $out.= '<div class="orsee-table-cell" data-label="'.lang('type').'">'.$upload['upload_suffix'].'</div>';
+                    $out.= '<div class="orsee-table-cell" data-label="'.lang('type').'">'.htmlspecialchars($upload['upload_suffix'],ENT_QUOTES,'UTF-8').'</div>';
                 }
                 if ($showdate) {
                     $out.= '<div class="orsee-table-cell" data-label="'.lang('date').'">'.ortime__format($upload['upload_id'],'',lang('lang')).'</div>';
@@ -239,7 +239,7 @@ function downloads__list_files_experiment($experiment_id,$showsize=false,$showty
                                 '/'.rawurlencode($upload['upload_name'].'.'.$upload['upload_suffix']).
                                 '?t=d&i='.$upload['upload_id'].'">';
                 }
-                $out.= $upload['upload_name'];
+                $out.= htmlspecialchars($upload['upload_name'],ENT_QUOTES,'UTF-8');
                 if ($allow_dl) {
                     $out.= '</A>';
                 }
@@ -248,7 +248,7 @@ function downloads__list_files_experiment($experiment_id,$showsize=false,$showty
                     $out.= '<div class="orsee-table-cell" data-label="'.lang('size').'">'.number_format(round($upload['upload_filesize']/1024),0).' KB</div>';
                 }
                 if ($showtype) {
-                    $out.= '<div class="orsee-table-cell" data-label="'.lang('type').'">'.$upload['upload_suffix'].'</div>';
+                    $out.= '<div class="orsee-table-cell" data-label="'.lang('type').'">'.htmlspecialchars($upload['upload_suffix'],ENT_QUOTES,'UTF-8').'</div>';
                 }
                 if ($showdate) {
                     $out.= '<div class="orsee-table-cell" data-label="'.lang('date').'">'.ortime__format($upload['upload_id'],'',lang('lang')).'</div>';


### PR DESCRIPTION
A few bug fixes:
- Session PDF participant list sent by email contained only placeholders (***). 
- Check whether email is assigned to user (previously checked wrong field).
- Email module participant-assign dropdown: If no matching email address was found for an incoming email, participant-assign dropdown now properly shows list of session participants once the email is assigned to a session. 
- Security: Encode search_sort and upload_name before output to prevent XSS